### PR TITLE
feat(cache): Integrar o cache do Redis no AcademicService

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,6 +44,9 @@ services:
       RABBITMQ_USERNAME: admin
       RABBITMQ_PASSWORD: admin123
 
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+
     ports:
       - "8080:8080"
     networks:

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,18 @@
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+
+
+
         <!-- TESTES -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/br/com/ifrn/AcademicService/AcademicServiceApplication.java
+++ b/src/main/java/br/com/ifrn/AcademicService/AcademicServiceApplication.java
@@ -1,5 +1,6 @@
 package br.com.ifrn.AcademicService;
 
+import br.com.ifrn.AcademicService.config.redis.RedisPropertiesConfig;
 import br.com.ifrn.AcademicService.file.objectstorage.MinioPropertiesConfig;
 import br.com.ifrn.AcademicService.keycloak.KeycloakPropertiesConfig;
 import org.springframework.boot.SpringApplication;
@@ -8,7 +9,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 
 @EnableConfigurationProperties({
         KeycloakPropertiesConfig.class,
-        MinioPropertiesConfig.class
+        MinioPropertiesConfig.class,
+        RedisPropertiesConfig.class
 })
 @SpringBootApplication
 public class AcademicServiceApplication {

--- a/src/main/java/br/com/ifrn/AcademicService/config/redis/RedisCacheConfig.java
+++ b/src/main/java/br/com/ifrn/AcademicService/config/redis/RedisCacheConfig.java
@@ -1,0 +1,72 @@
+package br.com.ifrn.AcademicService.config.redis;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+    @Autowired
+    RedisPropertiesConfig redisENV;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        String redisHost = redisENV.host();
+        int redisPort = redisENV.port();
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+
+        // Serialização em JSON para valores
+        RedisSerializationContext.SerializationPair<Object> jsonSerializer =
+                RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer());
+
+        // Configuração default com TTL de 30 min, sem cache de valores nulos e JSON
+        RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .disableCachingNullValues()
+                .serializeValuesWith(jsonSerializer);
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+        // StudentPerformance caches
+        cacheConfigurations.put("studentPerformanceCache", defaultCacheConfig.entryTtl(Duration.ofMinutes(20)));
+        cacheConfigurations.put("studentPerformanceCacheAll", defaultCacheConfig.entryTtl(Duration.ofMinutes(15)));
+
+        // Courses caches
+        cacheConfigurations.put("coursesCache", defaultCacheConfig.entryTtl(Duration.ofMinutes(20)));
+        cacheConfigurations.put("coursesCacheAll", defaultCacheConfig.entryTtl(Duration.ofMinutes(15)));
+
+        // Classes caches
+        cacheConfigurations.put("classesCache", defaultCacheConfig.entryTtl(Duration.ofMinutes(20)));
+        cacheConfigurations.put("classesCacheAll", defaultCacheConfig.entryTtl(Duration.ofMinutes(15)));
+
+        // ClassComments caches
+        cacheConfigurations.put("commentsCache", defaultCacheConfig.entryTtl(Duration.ofMinutes(10)));
+
+        // ClassEvaluations caches
+        cacheConfigurations.put("evaluationsCache", defaultCacheConfig.entryTtl(Duration.ofMinutes(20)));
+        cacheConfigurations.put("evaluationsCacheAll", defaultCacheConfig.entryTtl(Duration.ofMinutes(10)));
+        cacheConfigurations.put("evaluationsCacheByClass", defaultCacheConfig.entryTtl(Duration.ofMinutes(15)));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(defaultCacheConfig)
+                .withInitialCacheConfigurations(cacheConfigurations)
+                .build();
+    }
+
+}

--- a/src/main/java/br/com/ifrn/AcademicService/config/redis/RedisPropertiesConfig.java
+++ b/src/main/java/br/com/ifrn/AcademicService/config/redis/RedisPropertiesConfig.java
@@ -1,0 +1,10 @@
+package br.com.ifrn.AcademicService.config.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "redis")
+public record RedisPropertiesConfig(
+        String host,
+        int port
+) {}
+

--- a/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestClassDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestClassDTO.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Getter @Setter
-public class RequestClassDTO {
+public class RequestClassDTO implements Serializable {
 
     @NotNull
     @Size(min = 1, max = 100)

--- a/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestClassEvaluationsDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestClassEvaluationsDTO.java
@@ -6,7 +6,7 @@ import org.hibernate.validator.constraints.Range;
 
 
 @Getter @Setter
-public class RequestClassEvaluationsDTO {
+public class RequestClassEvaluationsDTO  {
 
     @Range(min = 0, max = 5)
     private float frequencyScore; //frequencia

--- a/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestCommentDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestCommentDTO.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Getter @Setter
-public class RequestCommentDTO {
+public class RequestCommentDTO implements Serializable {
     @NotNull
     @Size(min = 1, max = 1000)
     private String comment;

--- a/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestCourseDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestCourseDTO.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Getter @Setter
-public class RequestCourseDTO {
+public class RequestCourseDTO implements Serializable {
     @Size(min = 1, max = 100)
     @NotBlank
     private String name;

--- a/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestStudentPerformanceDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestStudentPerformanceDTO.java
@@ -4,8 +4,10 @@ package br.com.ifrn.AcademicService.dto.request;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Getter @Setter
-public class RequestStudentPerformanceDTO {
+public class RequestStudentPerformanceDTO implements Serializable {
     private String studentId;
     private String classId;
     private float averageScore;

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassDTO.java
@@ -6,10 +6,11 @@ import br.com.ifrn.AcademicService.models.Courses;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Getter @Setter
-public class ResponseClassDTO {
+public class ResponseClassDTO implements Serializable {
     private int id;
     private String name;
     private String semester;

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassEvaluationsDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassEvaluationsDTO.java
@@ -4,11 +4,12 @@ import br.com.ifrn.AcademicService.models.EvaluationsCriteria;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 
 
 @Getter @Setter
-public class ResponseClassEvaluationsDTO {
+public class ResponseClassEvaluationsDTO implements Serializable {
     private Integer id;
     private String classId;
     private Integer professorId;

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseCommentDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseCommentDTO.java
@@ -3,9 +3,11 @@ package br.com.ifrn.AcademicService.dto.response;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Getter
 @Setter
-public class ResponseCommentDTO {
+public class ResponseCommentDTO implements Serializable {
     private int id;
     private String comment;
 }

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseCourseDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseCourseDTO.java
@@ -3,8 +3,10 @@ package br.com.ifrn.AcademicService.dto.response;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Getter @Setter
-public class ResponseCourseDTO {
+public class ResponseCourseDTO implements Serializable {
     private int id;
     private String name;
     private String description;

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseStudentPerformanceDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseStudentPerformanceDTO.java
@@ -3,8 +3,10 @@ package br.com.ifrn.AcademicService.dto.response;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.io.Serializable;
+
 @Getter @Setter
-public class ResponseStudentPerformanceDTO {
+public class ResponseStudentPerformanceDTO implements Serializable {
     private Integer id;
     private String studentId;
     private String classId;

--- a/src/main/java/br/com/ifrn/AcademicService/repository/ClassCommentsRepository.java
+++ b/src/main/java/br/com/ifrn/AcademicService/repository/ClassCommentsRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ClassCommentsRepository extends JpaRepository<ClassComments, Integer> {
-    List<ClassComments> findByClasse_Id(Integer classeId);
+    List<ClassComments> findByClasseId(Integer classId);
 }

--- a/src/main/java/br/com/ifrn/AcademicService/services/ClassCommentsService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/ClassCommentsService.java
@@ -4,10 +4,11 @@ import br.com.ifrn.AcademicService.models.ClassComments;
 import br.com.ifrn.AcademicService.repository.ClassCommentsRepository;
 import br.com.ifrn.AcademicService.repository.ClassesRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
 import java.util.List;
 
 @Service
@@ -18,12 +19,12 @@ public class ClassCommentsService {
     @Autowired
     private ClassesRepository classesRepository;
 
+    @Cacheable(value = "commentsCache", key = "#turmaId")
     public List<ClassComments> getByTurma(Integer turmaId) {
-        return commentRepository.findAll().stream()
-                .filter(c -> c.getClasse().getId() == turmaId)
-                .toList();
+        return commentRepository.findByClasseId(turmaId);
     }
 
+    @CacheEvict(value = "commentsCache", allEntries = true)
     public ClassComments create(ClassComments comment) {
         if (comment.getComment() == null) {
             throw new IllegalArgumentException("Comentário não pode ser nulo");
@@ -40,6 +41,7 @@ public class ClassCommentsService {
         return commentRepository.save(comment);
     }
 
+    @CacheEvict(value = "commentsCache", allEntries = true)
     public ClassComments update(ClassComments comment) {
         ClassComments classComment = commentRepository.findById(comment.getId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ccomentário não encontrado!"));
@@ -48,6 +50,7 @@ public class ClassCommentsService {
         return commentRepository.save(classComment);
     }
 
+    @CacheEvict(value = "commentsCache", allEntries = true)
     public void delete(Integer id) {
         commentRepository.deleteById(id); }
 }

--- a/src/main/java/br/com/ifrn/AcademicService/services/ClassEvaluationsService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/ClassEvaluationsService.java
@@ -7,6 +7,8 @@ import br.com.ifrn.AcademicService.models.ClassEvaluations;
 import br.com.ifrn.AcademicService.models.EvaluationsCriteria;
 import br.com.ifrn.AcademicService.repository.ClassEvaluationsRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -22,6 +24,7 @@ public class ClassEvaluationsService {
     @Autowired
     EvaluationsMapper evaluationsMapper;
 
+    @Cacheable(value = "evaluationsCacheAll")
     public List<ResponseClassEvaluationsDTO> getAllEvaluations() {
 
         List<ClassEvaluations> classEvaluations = classEvaluationsRepository.findAll();
@@ -34,6 +37,7 @@ public class ClassEvaluationsService {
 
     }
 
+    @Cacheable(value = "evaluationsCache", key = "#id")
     public ResponseClassEvaluationsDTO getEvaluationById(Integer id) {
         ClassEvaluations classEvaluations = classEvaluationsRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("Evaluation not found"));
@@ -44,6 +48,7 @@ public class ClassEvaluationsService {
         return responseDTO;
     }
 
+    @Cacheable(value = "evaluationsCacheByClass", key = "#id")
     public List<ResponseClassEvaluationsDTO> getEvaluationsByClassId(Integer id) {
         List<ClassEvaluations> classEvaluations = classEvaluationsRepository.findByClassId(id);
         List<ResponseClassEvaluationsDTO> responseDTO = classEvaluations
@@ -53,6 +58,7 @@ public class ClassEvaluationsService {
         return responseDTO;
     }
 
+    @CacheEvict(value = {"evaluationsCacheAll", "evaluationsCacheByClass"}, key = "#classId")
     public ResponseClassEvaluationsDTO createEvaluation(RequestClassEvaluationsDTO dto, String classId, Integer professorId) {
         EvaluationsCriteria evaluations = evaluationsMapper.toEvaluationsCriteria(dto);
         ClassEvaluations classEvaluations = new  ClassEvaluations();
@@ -65,6 +71,7 @@ public class ClassEvaluationsService {
         return evaluationsMapper.toResponseClassEvaluationsDTO(classEvaluations);
     }
 
+    @CacheEvict(value = {"evaluationsCacheAll", "evaluationsCache", "evaluationsCacheByClass"}, key = "#entity.classId")
     public ResponseClassEvaluationsDTO updateEvaluation(Integer id, RequestClassEvaluationsDTO dto) {
         ClassEvaluations entity = classEvaluationsRepository.findById(id)
                 .orElseThrow(()-> new NoSuchElementException("ClassEvaluations not found with id: " + id));
@@ -76,6 +83,7 @@ public class ClassEvaluationsService {
         return responseDTO;
     }
 
+    @CacheEvict(value = {"evaluationsCacheAll", "evaluationsCache", "evaluationsCacheByClass"}, key = "#classId")
     public void deleteEvaluation(Integer id) {
         if (!classEvaluationsRepository.existsById(id)){
             throw new NoSuchElementException("ClassEvaluations not found with id: " + id);

--- a/src/main/java/br/com/ifrn/AcademicService/services/ClassesService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/ClassesService.java
@@ -4,6 +4,8 @@ package br.com.ifrn.AcademicService.services;
 import br.com.ifrn.AcademicService.models.Courses;
 import br.com.ifrn.AcademicService.repository.ClassesRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import br.com.ifrn.AcademicService.models.Classes;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,8 +24,13 @@ public class ClassesService {
     @Autowired
     CoursesService coursesService;
 
+    @Cacheable(value = "classesCacheAll")
     public List<Classes> getAll() { return classesRepository.findAll(); }
+
+    @Cacheable(value = "classesCache", key = "#id")
     public Optional<Classes> getById(Integer id) { return classesRepository.findById(id); }
+
+    @CacheEvict(value = "classesCacheAll", allEntries = true)
     public Classes create(Classes turma) {
 
         if (turma.getName() == null) {
@@ -39,6 +46,7 @@ public class ClassesService {
 
         return classesRepository.save(turma); }
 
+    @CacheEvict(value = {"classesCacheAll", "classesCache"}, allEntries = true)
     @Transactional
     public Classes update(Integer id, Classes turmaDetails) {
         Classes turma = classesRepository.findById(id).orElseThrow();
@@ -46,6 +54,8 @@ public class ClassesService {
         turma.setCourse(turmaDetails.getCourse());
         return classesRepository.save(turma);
     }
+
+    @CacheEvict(value = {"classesCacheAll", "classesCache"}, allEntries = true)
     public boolean delete(Integer id) { classesRepository.deleteById(id);
         return false;
     }
@@ -88,6 +98,7 @@ public class ClassesService {
      *
      * @throws IllegalArgumentException if {@code classId} is {@code null}.
      */
+    @CacheEvict(value = {"classesCacheAll", "classesCache"}, allEntries = true)
     @Transactional
     public Classes createOrUpdateClassByClassId(
             String courseName, String semester, Integer gradleLevel,

--- a/src/main/java/br/com/ifrn/AcademicService/services/CoursesService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/CoursesService.java
@@ -3,6 +3,8 @@ package br.com.ifrn.AcademicService.services;
 import br.com.ifrn.AcademicService.models.Courses;
 import br.com.ifrn.AcademicService.repository.CoursesRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
@@ -13,11 +15,16 @@ public class CoursesService {
     @Autowired
     private CoursesRepository coursesRepository;
 
-
-
-
+    @Cacheable(value = "coursesCacheAll")
     public List<Courses> getAll() { return coursesRepository.findAll(); }
-    public Optional<Courses> getById(Integer id) { return coursesRepository.findById(id); }
+
+    @Cacheable(value = "coursesCache", key = "#id")
+
+
+    public Optional<Courses> getById(Integer id) {
+        return coursesRepository.findById(id); }
+
+    @CacheEvict(value = "coursesCacheAll", allEntries = true)
     public Courses create(Courses course) {
         if (course.getName() == null) {
             throw new IllegalArgumentException("Nome do curso não pode ser nulo");
@@ -34,6 +41,7 @@ public class CoursesService {
         return coursesRepository.save(course);
     }
 
+    @CacheEvict(value = {"coursesCacheAll", "coursesCache"}, allEntries = true)
     public Courses update(Integer id, Courses courseDetails) {
         if (courseDetails.getName() == null) {
             throw new IllegalArgumentException("Nome do curso não pode ser nulo");
@@ -49,19 +57,23 @@ public class CoursesService {
         course.setDescription(courseDetails.getDescription());
         return coursesRepository.save(course);
     }
+
+    @CacheEvict(value = {"coursesCacheAll", "coursesCache"}, allEntries = true)
     public boolean delete(Integer id) { coursesRepository.deleteById(id);
         return false;
     }
 
+    @CacheEvict(value = "coursesCacheAll", allEntries = true)
     public Courses findOrCreateByName(String name) {
         Courses course = coursesRepository.findByName(name);
         if (course == null) {
-            course = new Courses();          // ← você esqueceu isso
+            course = new Courses();
             course.setName(name);
             course = coursesRepository.save(course);
         }
         return course;
     }
+
 
 
 }

--- a/src/main/java/br/com/ifrn/AcademicService/services/StudentPerformanceService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/StudentPerformanceService.java
@@ -8,6 +8,8 @@ import br.com.ifrn.AcademicService.models.StudentPerformance;
 import br.com.ifrn.AcademicService.repository.StudentPerformanceRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -21,6 +23,7 @@ public class StudentPerformanceService {
     @Autowired
     StudentPerformanceMapper mapper;
 
+    @Cacheable(value = "studentPerformanceCache", key = "#id")
     public ResponseStudentPerformanceDTO getStudentPerformanceById(Integer id) throws EntityNotFoundException {
 
         StudentPerformance studentPerformance = studentPerformanceRepository.findById(id)
@@ -29,6 +32,7 @@ public class StudentPerformanceService {
         return dto;
     }
 
+    @CacheEvict(value = "studentPerformanceCacheAll", allEntries = true)
     public ResponseStudentPerformanceDTO createStudentPerformance(RequestStudentPerformanceDTO requestDTO) {
         StudentPerformance studentPerformance = mapper.toEntity(requestDTO);
         studentPerformance = studentPerformanceRepository.save(studentPerformance);
@@ -36,6 +40,7 @@ public class StudentPerformanceService {
         return responseDto;
     }
 
+    @CacheEvict(value = {"studentPerformanceCache", "studentPerformanceCacheAll"}, allEntries = true)
     public ResponseStudentPerformanceDTO updateStudentPerformance(Integer id, RequestStudentPerformanceDTO dto) {
         StudentPerformance studentPerformance = studentPerformanceRepository.findById(id)
                 .orElseThrow(()-> new EntityNotFoundException("Not found Student Performance by Id: " + id));
@@ -49,6 +54,7 @@ public class StudentPerformanceService {
         return null;
     }
 
+    @CacheEvict(value = "studentPerformanceCacheAll", allEntries = true)
     public ResponseStudentPerformanceDTO createStudentPerformanceByConsumerMessageDTO(ImportMessageDTO consumerMessageDTO) {
         //estrutura inicial
         ResponseStudentPerformanceDTO responseDto =  new ResponseStudentPerformanceDTO();
@@ -62,6 +68,7 @@ public class StudentPerformanceService {
         return responseDto;
     }
 
+    @Cacheable(value = "studentPerformanceCacheAll")
     public List<ResponseStudentPerformanceDTO> getAllStudentPerformance() {
         List<StudentPerformance> studentPerformanceList = studentPerformanceRepository.findAll();
         return studentPerformanceList.stream()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,6 +31,9 @@ spring:
     username: ${RABBITMQ_USERNAME}
     password: ${RABBITMQ_PASSWORD}
 
+  cache:
+    type: redis
+
 # Configuração do Swagger/OpenAPI
 springdoc:
   swagger-ui:
@@ -66,3 +69,6 @@ minio:
   admin-password: ${MINIO_ROOT_PASSWORD}
   bucket-files: ${BUCKET_FILES_NAME}
   bucket-images: ${BUCKET_IMAGES_NAME}
+redis:
+  host: ${REDIS_HOST}
+  port: ${REDIS_PORT}


### PR DESCRIPTION

**Descrição:**
Esta PR introduz o cache do Redis em toda a aplicação AcademicService para melhorar o desempenho e reduzir a carga do banco de dados. As principais alterações incluem:

* Adicionada configuração do Redis (`RedisCacheConfig` e `RedisPropertiesConfig`)
* Habilitado o cache nos serviços principais: `ClassesService`, `CoursesService`, `StudentPerformanceService`, `ClassCommentsService`, `ClassEvaluationsService`
* Aplicadas as anotações `@Cacheable` e `@CacheEvict` para um gerenciamento de cache eficiente
* Docker Compose atualizado para incluir variáveis ​​de ambiente do Redis
* Adicionadas dependências do Spring Boot para Redis e cache
* DTOs serializáveis ​​para suportar o cache do Redis

**Testes**
* Foi criado um método para simular a latência de uma requisição sem cache
<img width="415" height="277" alt="Captura de tela 2025-12-17 132823" src="https://github.com/user-attachments/assets/5808b167-3db9-48d8-a44b-a0610e5145bb" />



* Na primeira requisição, os dados ainda não estão salvo no redis, então demora devido a latência simulada
* Tempo de resposta: 5.02 segundos.
<img width="1297" height="329" alt="Captura de tela 2025-12-17 133339" src="https://github.com/user-attachments/assets/4950fec5-979d-48d2-bedd-c9897990e832" />


* Após a primeira requisição, todas que pesquisarem pelo mesmo ID, receberão as respostas do cache, sem consultar o banco de dados.
* Tempo de resposta: 14 milissegundos.
<img width="1292" height="354" alt="Captura de tela 2025-12-17 133415" src="https://github.com/user-attachments/assets/a49b6dd7-c9cf-41e2-8cf1-bd001c484490" />

