### PR TITLE
Setup prometheus monitoring and dynamic cors configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
         <commons-csv.version>1.14.1</commons-csv.version>
         <poi-ooxml.version>5.5.0</poi-ooxml.version>
         <minio.version>8.6.0</minio.version>
+        <actuator.version>4.0.1</actuator.version>
+        <micrometer.version>1.16.1</micrometer.version>
 
     </properties>
 
@@ -147,6 +149,23 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+
+        <!-- Source: https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-actuator -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>${actuator.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Source: https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-prometheus -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${micrometer.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <!-- TESTES -->

--- a/src/main/java/br/com/ifrn/AcademicService/config/security/SecurityConfig.java
+++ b/src/main/java/br/com/ifrn/AcademicService/config/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package br.com.ifrn.AcademicService.config.security;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,6 +17,10 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig implements WebMvcConfigurer {
+
+    @Value("${SPRING_FRONTEND_URL:http://localhost:5173}")
+    private String frontendUrl;
+
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
@@ -27,11 +32,11 @@ public class SecurityConfig implements WebMvcConfigurer {
                             authorizeConfig.requestMatchers(
                                     "/",                       // Raiz para o redirect funcionar
                                     "/api/docs/**",            // Onde está o seu Swagger UI
-                                    "/api/docs/index.html",    // Caminho direto do Swagger
                                     "/v3/api-docs/**",         // Onde está o JSON (importante!)
                                     "/swagger-ui/**",          // Caminhos internos da lib
                                     "/webjars/**"              // Arquivos CSS/JS do Swagger
                             ).permitAll();
+                            authorizeConfig.requestMatchers("/actuator/**").permitAll();
                             authorizeConfig.requestMatchers("/public").permitAll();
                             authorizeConfig.requestMatchers("/logout").permitAll();
                             authorizeConfig.anyRequest().authenticated();
@@ -47,7 +52,7 @@ public class SecurityConfig implements WebMvcConfigurer {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:5173")); // Porta do React
+        configuration.setAllowedOrigins(List.of(frontendUrl, "http://localhost:5173")); // Porta do React
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -86,10 +86,10 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,loggers
+        include: prometheus, health, info, metrics, loggers
   endpoint:
-    health:
-      show-details: always
+    prometheus:
+      enabled: true
 
 keycloak:
   client-secret: ${KEYCLOAK_CLIENT_SECRET}


### PR DESCRIPTION
Add Spring Actuator and Micrometer Prometheus dependencies.

Expose /actuator/prometheus endpoint in application.yaml.

Update SecurityConfig to permit all requests to actuator endpoints.

Implement dynamic CORS origin using SPRING_FRONTEND_URL environment variable.