### PR TITLE
fix: resolve swagger 403 and enable proxy forward headers

### DIFF
--- a/src/main/java/br/com/ifrn/AcademicService/config/security/SecurityConfig.java
+++ b/src/main/java/br/com/ifrn/AcademicService/config/security/SecurityConfig.java
@@ -21,6 +21,9 @@ public class SecurityConfig implements WebMvcConfigurer {
     @Value("${SPRING_FRONTEND_URL:http://localhost:5173}")
     private String frontendUrl;
 
+    @Value("${SPRING_SERVER_URL}")
+    private String backendUrl;
+
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
@@ -52,9 +55,15 @@ public class SecurityConfig implements WebMvcConfigurer {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(frontendUrl, "http://localhost:5173")); // Porta do React
+        // Lista de origens permitidas
+        configuration.setAllowedOrigins(List.of(
+                frontendUrl,
+                backendUrl,
+                "http://localhost:5173"
+        ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
+        configuration.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,6 @@
 server:
   port: ${SPRING_EXTERNAL_PORT}
+  forward-headers-strategy: framework
   error:
     include-message: always
     include-binding-errors: always
@@ -45,11 +46,11 @@ spring:
             #token-uri: ${KEYCLOAK_SERVER_URL}/realms/ifrn/protocol/openid-connect/token
             #jwk-set-uri: ${KEYCLOAK_SERVER_URL}/realms/ifrn/protocol/openid-connect/certs
             #user-info-uri: ${KEYCLOAK_SERVER_URL}/realms/ifrn/protocol/openid-connect/userinfo
-            issuer-uri: ${KEYCLOAK_SERVER_URL}/realms/ifrn
+            issuer-uri: ${KEYCLOAK_SERVER_URL}/realms/${KEYCLOAK_REALM}
       resourceserver:
         jwt:
           #jwk-set-uri: ${KEYCLOAK_SERVER_URL}/realms/ifrn/protocol/openid-connect/certs
-          issuer-uri: ${KEYCLOAK_SERVER_URL}/realms/ifrn
+          issuer-uri: ${KEYCLOAK_SERVER_URL}/realms/${KEYCLOAK_REALM}
 
   rabbitmq:
     host: ${RABBITMQ_HOST}
@@ -73,8 +74,8 @@ springdoc:
       client-id: swagger-ui
       use-pkce-with-authorization-code-grant: true
       scopes: openid profile email
-      authorization-url: ${KEYCLOAK_SERVER_URL}/realms/ifrn/protocol/openid-connect/auth
-      token-url: ${KEYCLOAK_SERVER_URL}/realms/ifrn/protocol/openid-connect/token
+      authorization-url: ${KEYCLOAK_SERVER_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/auth
+      token-url: ${KEYCLOAK_SERVER_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token
   show-actuator: true
 
 # Configuração global de CORS (opcional, mas útil no Swagger)


### PR DESCRIPTION
- Add forward-headers-strategy: framework to handle reverse proxy HTTPS.

- Dynamic Keycloak realm configuration using ${KEYCLOAK_REALM}.

- Update CORS to allow SPRING_SERVER_URL and enable credentials.

- Fix Swagger OAuth2 URLs to use dynamic realm variable.