### PR TITLE
Refactor classes service to use DTOs and fix Keycloak integration

### DIFF
--- a/src/main/java/br/com/ifrn/AcademicService/config/keycloak/KeycloakAdminConfig.java
+++ b/src/main/java/br/com/ifrn/AcademicService/config/keycloak/KeycloakAdminConfig.java
@@ -43,17 +43,21 @@ public class KeycloakAdminConfig {
     }
 
 
-    public UserRepresentation findKeycloakUser(String userId) {
-        Keycloak keycloak = createKeycloakAdminClient(); // cliente admin
+    public UserRepresentation findKeycloakUser(String userId) throws Exception {
+        try {
+            Keycloak keycloak = createKeycloakAdminClient();
 
-        List<UserRepresentation> users = keycloak.realm(envKeycloak.realm())
-                .users()
-                .search(userId);
-        if (users.isEmpty()) {
+            // Em vez de .search(), usamos .get(id) que foca no UUID interno
+            return keycloak.realm(envKeycloak.realm())
+                    .users()
+                    .get(userId) // Busca direta pelo UUID
+                    .toRepresentation();
+
+        } catch (Exception e) {
+            // Log para outros erros (conexão, timeout, etc)
+            System.err.println("Erro ao buscar usuário no Keycloak: " + e.getMessage());
             return null;
         }
-        UserRepresentation user = users.get(0);
-        return user;
     }
 
 }

--- a/src/main/java/br/com/ifrn/AcademicService/controller/ClassesController.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/ClassesController.java
@@ -3,6 +3,7 @@ package br.com.ifrn.AcademicService.controller;
 import br.com.ifrn.AcademicService.controller.docs.ClassesControllerDocs;
 import br.com.ifrn.AcademicService.dto.request.RequestClassDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseClassByIdDTO;
+import br.com.ifrn.AcademicService.dto.response.ResponseClassDTO;
 import br.com.ifrn.AcademicService.models.Classes;
 import br.com.ifrn.AcademicService.models.Courses;
 import br.com.ifrn.AcademicService.services.ClassesService;
@@ -24,8 +25,8 @@ public class ClassesController implements ClassesControllerDocs {
     private ClassesService classesService;
 
     @GetMapping
-    public ResponseEntity<List<Classes>> getAll() {
-        List<Classes> classesList = classesService.getAll();
+    public ResponseEntity<List<ResponseClassDTO>> getAll() {
+        List<ResponseClassDTO> classesList = classesService.getAll();
         if (classesList.isEmpty()) {
             return ResponseEntity.noContent().build();
         }
@@ -33,7 +34,7 @@ public class ClassesController implements ClassesControllerDocs {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ResponseClassByIdDTO> getById(@PathVariable Integer id) {
+    public ResponseEntity<ResponseClassByIdDTO> getById(@PathVariable Integer id) throws Exception {
         ResponseClassByIdDTO classes = classesService.getByClassId(id);
         if (classes == null) {
             return ResponseEntity.notFound().build();

--- a/src/main/java/br/com/ifrn/AcademicService/controller/docs/ClassesControllerDocs.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/docs/ClassesControllerDocs.java
@@ -2,6 +2,7 @@ package br.com.ifrn.AcademicService.controller.docs;
 
 import br.com.ifrn.AcademicService.dto.request.RequestClassDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseClassByIdDTO;
+import br.com.ifrn.AcademicService.dto.response.ResponseClassDTO;
 import br.com.ifrn.AcademicService.models.Classes;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -21,7 +22,7 @@ public interface ClassesControllerDocs {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Lista de turmas retornada com sucesso"),
     })
-    ResponseEntity<List<Classes>> getAll();
+    ResponseEntity<List<ResponseClassDTO>> getAll();
 
     @Operation(summary = "Cria uma nova turma")
     @ApiResponses(value = {
@@ -37,7 +38,7 @@ public interface ClassesControllerDocs {
             @ApiResponse(responseCode = "200", description = "Turma encontrada com sucesso"),
             @ApiResponse(responseCode = "404", description = "Turma não encontrada"),
     })
-    ResponseEntity<ResponseClassByIdDTO> getById(Integer id);
+    ResponseEntity<ResponseClassByIdDTO> getById(Integer id) throws Exception;
 
     @Operation(summary = "Atualiza informações de uma turma existente")
     @ApiResponses(value = {

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassDTO.java
@@ -18,4 +18,6 @@ public class ResponseClassDTO implements Serializable {
     private String shift;
     private Courses course;
     private List<ClassComments> comments;
+    private List<String> userId;
+    private String classId;
 }

--- a/src/main/java/br/com/ifrn/AcademicService/mapper/ClassMapper.java
+++ b/src/main/java/br/com/ifrn/AcademicService/mapper/ClassMapper.java
@@ -1,11 +1,16 @@
 package br.com.ifrn.AcademicService.mapper;
 
 import br.com.ifrn.AcademicService.dto.response.ResponseClassByIdDTO;
+import br.com.ifrn.AcademicService.dto.response.ResponseClassDTO;
 import br.com.ifrn.AcademicService.models.Classes;
 import org.mapstruct.Mapper;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface ClassMapper {
 
     ResponseClassByIdDTO toResponseClassByDTO(Classes classes);
+
+    List<ResponseClassDTO> toResponseClassDTO(List<Classes> classes);
 }

--- a/src/main/java/br/com/ifrn/AcademicService/services/CoursesService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/CoursesService.java
@@ -26,19 +26,10 @@ public class CoursesService {
 
     @CacheEvict(value = "coursesCacheAll", allEntries = true)
     public Courses create(Courses course) {
-        if (course.getName() == null) {
-            throw new IllegalArgumentException("Nome do curso não pode ser nulo");
+        if (course.getName() == null || course.getName().isEmpty() || course.getName().length() > 255 || course.getDescription().length() > 500) {
+            throw new IllegalArgumentException("Nome ou Descrição do curso inválido!");
         }
-        if (course.getName().isEmpty()) {
-            throw new IllegalArgumentException("Nome do curso não pode ser vazio");
-        }
-        if (course.getName().length() > 255) {
-            throw new IllegalArgumentException("Nome do curso não pode exceder 255 caracteres");
-        }
-        if (course.getDescription().length() > 500) {
-            throw new IllegalArgumentException("Descrição do curso não pode exceder 500 caracteres");
-        }
-        return coursesRepository.save(course);
+        return findOrCreateByName(course.getName());
     }
 
     @CacheEvict(value = {"coursesCacheAll", "coursesCache"}, allEntries = true)

--- a/src/test/java/br/com/ifrn/AcademicService/ClassesServiceTest.java
+++ b/src/test/java/br/com/ifrn/AcademicService/ClassesServiceTest.java
@@ -1,5 +1,7 @@
 package br.com.ifrn.AcademicService;
 
+import br.com.ifrn.AcademicService.dto.response.ResponseClassDTO;
+import br.com.ifrn.AcademicService.mapper.ClassMapper;
 import br.com.ifrn.AcademicService.repository.ClassesRepository;
 import br.com.ifrn.AcademicService.services.ClassesService;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +19,8 @@ import static org.mockito.Mockito.*;
 
 @ActiveProfiles("test")
 class ClassesServiceTest {
+    @Mock
+    private ClassMapper classsMapper;
 
     @Mock
     private ClassesRepository classesRepository;
@@ -49,8 +53,17 @@ class ClassesServiceTest {
 
     @Test
     void testGetAll() {
-        when(classesRepository.findAll()).thenReturn(List.of(turma));
-        List<Classes> all = classesService.getAll();
+        Classes turmaEntity = new Classes();
+        turmaEntity.setName("Matemática");
+
+        ResponseClassDTO turmaDTO = new ResponseClassDTO();
+        turmaDTO.setName("Matemática");
+
+        when(classesRepository.findAll()).thenReturn(List.of(turmaEntity));
+        when(classsMapper.toResponseClassDTO(anyList())).thenReturn(List.of(turmaDTO));
+
+        List<ResponseClassDTO> all = classesService.getAll();
+
         assertEquals(1, all.size());
         assertEquals("Matemática", all.get(0).getName());
     }

--- a/src/test/java/br/com/ifrn/AcademicService/CoursesServiceTest.java
+++ b/src/test/java/br/com/ifrn/AcademicService/CoursesServiceTest.java
@@ -109,7 +109,7 @@ class CoursesServiceTest{
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             coursesService.create(course);
         });
-        assertEquals("Nome do curso não pode ser vazio", exception.getMessage());
+        assertEquals("Nome ou Descrição do curso inválido!", exception.getMessage());
     }
 
     @Test
@@ -118,7 +118,7 @@ class CoursesServiceTest{
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             coursesService.create(course);
         });
-        assertEquals("Nome do curso não pode ser nulo", exception.getMessage());
+        assertEquals("Nome ou Descrição do curso inválido!", exception.getMessage());
     }
 
     @Test
@@ -127,7 +127,7 @@ class CoursesServiceTest{
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             coursesService.create(course);
         });
-        assertEquals("Nome do curso não pode exceder 255 caracteres", exception.getMessage());
+        assertEquals("Nome ou Descrição do curso inválido!", exception.getMessage());
     }
 
     @Test
@@ -136,7 +136,7 @@ class CoursesServiceTest{
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             coursesService.create(course);
         });
-        assertEquals("Descrição do curso não pode exceder 500 caracteres", exception.getMessage());
+        assertEquals("Nome ou Descrição do curso inválido!", exception.getMessage());
     }
 
     // ==============================


### PR DESCRIPTION
- Refatoração: Alterado os endpoints de Classes para retornar ResponseClassDTO e ResponseClassByIdDTO, evitando erros de LazyInitializationException.

- Keycloak: Substituído o método .search() por .get().toRepresentation() para busca precisa via UUID e adicionado tratamento para usuários não encontrados.

- Performance: Adicionado @Transactional(readOnly = true) para garantir a sessão do Hibernate durante o carregamento de coleções.

- Fix: Corrigido o retorno do método getByClassId que estava devolvendo um objeto vazio e ajustado os testes unitários para mockar o novo ClassMapper.

- Clean Up: Simplificada a lógica de validação no CoursesService.