### PR TITLE
Refatorar infraestrutura de cache, segurança

### DIFF
--- a/src/main/java/br/com/ifrn/AcademicService/config/keycloak/KeycloakAdminConfig.java
+++ b/src/main/java/br/com/ifrn/AcademicService/config/keycloak/KeycloakAdminConfig.java
@@ -8,6 +8,10 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 @Component
 public class KeycloakAdminConfig {
 
@@ -51,6 +55,21 @@ public class KeycloakAdminConfig {
             System.err.println("Erro ao buscar usuário no Keycloak: " + e.getMessage());
             return null;
         }
+    }
+
+    public List<UserRepresentation> findKeycloakUsersByIds(List<String> ids) {
+        Keycloak keycloak = createKeycloakAdminClient();
+        var usersResource = keycloak.realm(envKeycloak.realm()).users();
+        return ids.stream()
+                .map(id -> {
+                    try {
+                        return usersResource.get(id).toRepresentation();
+                    } catch (Exception e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/br/com/ifrn/AcademicService/config/keycloak/KeycloakAdminConfig.java
+++ b/src/main/java/br/com/ifrn/AcademicService/config/keycloak/KeycloakAdminConfig.java
@@ -72,4 +72,20 @@ public class KeycloakAdminConfig {
                 .collect(Collectors.toList());
     }
 
+    public List<UserRepresentation> findUsersGroup(String nomeGrupo) {
+        Keycloak keycloak = createKeycloakAdminClient();
+        String grupoId = keycloak.realm(envKeycloak.realm())
+                .groups()
+                .groups().stream()
+                .filter(g -> g.getName().equalsIgnoreCase(nomeGrupo))
+                .findFirst()
+                .orElseThrow()
+                .getId();
+
+        // 2. Retornamos os membros desse grupo
+        return keycloak.realm(envKeycloak.realm())
+                .groups()
+                .group(grupoId)
+                .members();
+    }
 }

--- a/src/main/java/br/com/ifrn/AcademicService/config/security/SecurityConfig.java
+++ b/src/main/java/br/com/ifrn/AcademicService/config/security/SecurityConfig.java
@@ -3,19 +3,27 @@ package br.com.ifrn.AcademicService.config.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.Collection;
 import java.util.List;
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig implements WebMvcConfigurer {
 
     @Value("${SPRING_FRONTEND_URL:http://localhost:5173}")
@@ -75,6 +83,28 @@ public class SecurityConfig implements WebMvcConfigurer {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtGrantedAuthoritiesConverter defaultConverter = new JwtGrantedAuthoritiesConverter();
+
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            // 1. Pega as authorities padrão (como SCOPE_profile, SCOPE_email)
+            Collection<GrantedAuthority> authorities = defaultConverter.convert(jwt);
+
+            // 2. Pega o seu atributo customizado "type_user"
+            String typeUser = jwt.getClaimAsString("type_user");
+
+            if (typeUser != null) {
+                // Adicionamos o valor (Aluno/Professor) como uma permissão
+                authorities.add(new SimpleGrantedAuthority(typeUser));
+            }
+
+            return authorities;
+        });
+        return converter;
     }
 }
 

--- a/src/main/java/br/com/ifrn/AcademicService/controller/ClassCommentsController.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/ClassCommentsController.java
@@ -4,9 +4,7 @@ import br.com.ifrn.AcademicService.controller.docs.ClassCommentsControllerDocs;
 import br.com.ifrn.AcademicService.dto.request.RequestCommentDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseCommentDTO;
 import br.com.ifrn.AcademicService.models.ClassComments;
-import br.com.ifrn.AcademicService.models.Classes;
 import br.com.ifrn.AcademicService.services.ClassCommentsService;
-import br.com.ifrn.AcademicService.services.ClassesService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,8 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
-import java.time.LocalDate;
+
 import java.util.List;
 
 @RestController
@@ -25,8 +22,6 @@ public class ClassCommentsController implements ClassCommentsControllerDocs {
 
     @Autowired
     private ClassCommentsService commentService;
-
-
 
     @GetMapping
     public ResponseEntity<List<ResponseCommentDTO>> getByClass(@PathVariable Integer classId) {
@@ -38,8 +33,37 @@ public class ClassCommentsController implements ClassCommentsControllerDocs {
     }
 
     @PostMapping
-    public ResponseEntity<ClassComments> create(@PathVariable Integer classId, @RequestBody RequestCommentDTO commentDTO, Authentication authentication ) {
+    public ResponseEntity<ResponseCommentDTO> create(
+            @PathVariable Integer classId,
+            @RequestBody RequestCommentDTO commentDTO,
+            Authentication authentication ) {
 
+        String professorId = getProfessorId(authentication);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                commentService.create(commentDTO, professorId, classId)
+        );
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<ResponseCommentDTO> update(
+            @PathVariable Integer commentId,
+            @RequestBody RequestCommentDTO comment,
+            Authentication authentication) throws IllegalAccessException {
+
+        String professorId = getProfessorId(authentication);
+
+        return ResponseEntity.ok(commentService.update(commentId, comment, professorId));
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> delete(@PathVariable Integer classId, @PathVariable Integer commentId) {
+
+        commentService.delete(commentId);
+        return ResponseEntity.noContent().build();
+    }
+
+    private static String getProfessorId(Authentication authentication) {
         String professorId = null;
 
         if (authentication.getPrincipal() instanceof Jwt jwt) {
@@ -49,20 +73,6 @@ public class ClassCommentsController implements ClassCommentsControllerDocs {
         } else {
             professorId = authentication.getName();
         }
-        ClassComments createdComment = commentService.create(commentDTO, professorId, classId);
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdComment);
-    }
-
-    @PutMapping("/{commentId}")
-    public ResponseEntity<ClassComments> update(@PathVariable Integer classId, @PathVariable Integer commentId, @RequestBody ClassComments comment) {
-        comment.setId(commentId);
-        return ResponseEntity.ok(commentService.update(comment));
-    }
-
-    @DeleteMapping("/{commentId}")
-    public ResponseEntity<Void> delete(@PathVariable Integer classId, @PathVariable Integer commentId) {
-
-        commentService.delete(commentId);
-        return ResponseEntity.noContent().build();
+        return professorId;
     }
 }

--- a/src/main/java/br/com/ifrn/AcademicService/controller/ClassesController.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/ClassesController.java
@@ -5,17 +5,14 @@ import br.com.ifrn.AcademicService.dto.request.RequestClassDTO;
 import br.com.ifrn.AcademicService.dto.response.ClassPanelResponseDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseClassByIdDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseClassDTO;
-import br.com.ifrn.AcademicService.dto.response.ResponseclassificationsClassDTO;
 import br.com.ifrn.AcademicService.models.Classes;
-import br.com.ifrn.AcademicService.models.Courses;
-import br.com.ifrn.AcademicService.repository.ClassesRepository;
 import br.com.ifrn.AcademicService.services.ClassesService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -52,24 +49,13 @@ public class ClassesController implements ClassesControllerDocs {
     }
 
     @PostMapping
-    public ResponseEntity<Classes> create(@RequestParam Integer courseId, @RequestBody RequestClassDTO classDTO) {
-        Courses curso = classesService.getById(courseId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Curso não encontrado!")).getCourse();
-
-        Classes createdClasses = new Classes();
-        createdClasses.setCourse(curso);
-        createdClasses.setName(classDTO.getName());
-        createdClasses.setClassId(classDTO.getClassId());
-        createdClasses.setShift(classDTO.getShift());
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(classesService.create(createdClasses));
+    public ResponseEntity<ResponseClassDTO> create(@RequestParam Integer courseId, @RequestBody RequestClassDTO classDTO) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(classesService.create(courseId, classDTO));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Classes> update(@PathVariable Integer id, @RequestBody Classes classes) {
-        Optional<Classes> updatedClasses = Optional.ofNullable(classesService.update(id, classes));
-        return updatedClasses.map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).body(null));
+    public ResponseEntity<ResponseClassDTO> update(@PathVariable Integer id, @PathVariable Integer courseId, @RequestBody RequestClassDTO classes) {
+        return ResponseEntity.status(HttpStatus.OK).body(classesService.update(id, courseId, classes));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/br/com/ifrn/AcademicService/controller/CoursesController.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/CoursesController.java
@@ -3,6 +3,7 @@ package br.com.ifrn.AcademicService.controller;
 import br.com.ifrn.AcademicService.controller.docs.CoursesControllerDocs;
 import br.com.ifrn.AcademicService.dto.request.RequestCourseDTO;
 import br.com.ifrn.AcademicService.dto.response.CoursePanelResponseDTO;
+import br.com.ifrn.AcademicService.dto.response.ResponseCourseDTO;
 import br.com.ifrn.AcademicService.models.Courses;
 import br.com.ifrn.AcademicService.services.CoursesService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/courses")
@@ -20,19 +20,14 @@ public class CoursesController implements CoursesControllerDocs {
     private CoursesService courseService;
 
     @GetMapping
-    public ResponseEntity<List<Courses>> getAll() {
-        List<Courses> coursesList = courseService.getAll();
-        if (coursesList.isEmpty()) {
-            return ResponseEntity.noContent().build();
-        }
+    public ResponseEntity<List<ResponseCourseDTO>> getAll() {
+        List<ResponseCourseDTO> coursesList = courseService.getAll();
         return ResponseEntity.ok(coursesList);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Courses> getById(@PathVariable Integer id) {
-        Optional<Courses> course = courseService.getById(id);
-        return course.map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).body(null));
+    public ResponseEntity<ResponseCourseDTO> getById(@PathVariable Integer id) {
+        return ResponseEntity.ok(courseService.getById(id));
     }
 
     @GetMapping("/panel")
@@ -42,18 +37,13 @@ public class CoursesController implements CoursesControllerDocs {
     }
 
     @PostMapping
-    public ResponseEntity<Courses> create(@RequestBody RequestCourseDTO courseDTO) {
-        Courses createdCourse = new Courses();
-        createdCourse.setName(courseDTO.getName());
-        return ResponseEntity.status(HttpStatus.CREATED).body(courseService.create(createdCourse));
+    public ResponseEntity<ResponseCourseDTO> create(@RequestBody RequestCourseDTO courseDTO) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(courseService.create(courseDTO));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Courses> update(@PathVariable Integer id, @RequestBody RequestCourseDTO courseDTO) {
-        Courses course = new Courses();
-        course.setName(courseDTO.getName());
-        Courses updatedCourse = courseService.update(id, course);
-        return ResponseEntity.ok(updatedCourse);
+    public ResponseEntity<ResponseCourseDTO> update(@PathVariable Integer id, @RequestBody RequestCourseDTO courseDTO) {
+        return ResponseEntity.ok(courseService.update(id, courseDTO));
     }
 
 

--- a/src/main/java/br/com/ifrn/AcademicService/controller/StudentPerformanceController.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/StudentPerformanceController.java
@@ -2,6 +2,7 @@ package br.com.ifrn.AcademicService.controller;
 
 import br.com.ifrn.AcademicService.controller.docs.StudentPerformanceControllerDocs;
 import br.com.ifrn.AcademicService.dto.request.RequestStudentPerformanceDTO;
+import br.com.ifrn.AcademicService.dto.request.RequestStudentPerformanceUpdateDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseStudentPerformanceDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseclassificationsClassDTO;
 import br.com.ifrn.AcademicService.services.StudentPerformanceService;
@@ -9,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 
 @RestController
@@ -40,7 +40,7 @@ public class StudentPerformanceController implements StudentPerformanceControlle
         return ResponseEntity.status(HttpStatus.CREATED).body(studentPerformanceService.createStudentPerformance(performanceDTO));
     }
     @PutMapping("/class/{id}")
-    public ResponseEntity<ResponseStudentPerformanceDTO> updateStudentEvaluation(@PathVariable Integer id, @RequestBody RequestStudentPerformanceDTO dto) {
+    public ResponseEntity<ResponseStudentPerformanceDTO> updateStudentEvaluation(@PathVariable Integer id, @RequestBody RequestStudentPerformanceUpdateDTO dto) {
         return ResponseEntity.ok().body(studentPerformanceService.updateStudentPerformance(id, dto));
     }
 }

--- a/src/main/java/br/com/ifrn/AcademicService/controller/docs/ClassCommentsControllerDocs.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/docs/ClassCommentsControllerDocs.java
@@ -29,7 +29,7 @@ public interface ClassCommentsControllerDocs {
             @ApiResponse(responseCode = "400", description = "Requisição inválida"),
             @ApiResponse(responseCode = "404", description = "Turma não encontrada")
     })
-    ResponseEntity<ClassComments> create(Integer classId, RequestCommentDTO commentDTO, Authentication authentication);
+    ResponseEntity<ResponseCommentDTO> create(Integer classId, RequestCommentDTO commentDTO, Authentication authentication);
 
     @Operation(summary = "Edita um comentário existente")
     @ApiResponses(value = {
@@ -39,7 +39,7 @@ public interface ClassCommentsControllerDocs {
             @ApiResponse(responseCode = "403", description = "Acesso proibido"),
             @ApiResponse(responseCode = "404", description = "Comentário ou turma não encontrada"),
     })
-    ResponseEntity<ClassComments> update(Integer classId, Integer commentId, ClassComments comment);
+    ResponseEntity<ResponseCommentDTO> update(Integer commentId, RequestCommentDTO comment, Authentication authentication) throws IllegalAccessException;
 
     @Operation(summary = "Remove um comentário existente")
     @ApiResponses(value = {

--- a/src/main/java/br/com/ifrn/AcademicService/controller/docs/ClassesControllerDocs.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/docs/ClassesControllerDocs.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 
 
 import java.util.List;
@@ -34,7 +35,7 @@ public interface ClassesControllerDocs {
             @ApiResponse(responseCode = "404", description = "Curso não encontrado"),
             @ApiResponse(responseCode = "409", description = "Conflito ao criar turma"),
     })
-    ResponseEntity<Classes> create(Integer courseId, RequestClassDTO classDTO);
+    ResponseEntity<ResponseClassDTO> create(Integer courseId, RequestClassDTO classDTO);
 
     @Operation(summary = "Recupera detalhes de uma turma específica")
     @ApiResponses(value = {
@@ -51,7 +52,7 @@ public interface ClassesControllerDocs {
             @ApiResponse(responseCode = "401", description = "Usuário não autenticado"),
             @ApiResponse(responseCode = "404", description = "Turma não encontrada"),
     })
-    ResponseEntity<Classes> update(Integer id, Classes classes);
+    ResponseEntity<ResponseClassDTO> update(Integer id, Integer courseId, RequestClassDTO classes);
 
     @Operation(summary = "Remove uma turma do sistema")
     @ApiResponses(value = {

--- a/src/main/java/br/com/ifrn/AcademicService/controller/docs/CoursesControllerDocs.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/docs/CoursesControllerDocs.java
@@ -2,7 +2,7 @@ package br.com.ifrn.AcademicService.controller.docs;
 
 import br.com.ifrn.AcademicService.dto.request.RequestCourseDTO;
 import br.com.ifrn.AcademicService.dto.response.CoursePanelResponseDTO;
-import br.com.ifrn.AcademicService.models.Courses;
+import br.com.ifrn.AcademicService.dto.response.ResponseCourseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,7 +22,7 @@ public interface CoursesControllerDocs {
             @ApiResponse(responseCode = "401", description = "Usuário não autenticado"),
             @ApiResponse(responseCode = "500", description = "Erro interno do servidor")
     })
-    ResponseEntity<List<Courses>> getAll();
+    ResponseEntity<List<ResponseCourseDTO>> getAll();
 
     @Operation(summary = "Cria um novo curso")
     @ApiResponses(value = {
@@ -32,7 +32,7 @@ public interface CoursesControllerDocs {
             @ApiResponse(responseCode = "409", description = "Conflito ao criar curso"),
             @ApiResponse(responseCode = "500", description = "Erro interno do servidor")
     })
-    ResponseEntity<Courses> create(RequestCourseDTO courseDTO);
+    ResponseEntity<ResponseCourseDTO> create(RequestCourseDTO courseDTO);
 
     @Operation(summary = "Recupera detalhes de um curso específico")
     @ApiResponses(value = {
@@ -41,7 +41,7 @@ public interface CoursesControllerDocs {
             @ApiResponse(responseCode = "404", description = "Curso não encontrado"),
             @ApiResponse(responseCode = "500", description = "Erro interno do servidor")
     })
-    ResponseEntity<Courses> getById(Integer id);
+    ResponseEntity<ResponseCourseDTO> getById(Integer id);
 
     @Operation(summary = "Atualiza informações de um curso existente")
     @ApiResponses(value = {
@@ -51,7 +51,7 @@ public interface CoursesControllerDocs {
             @ApiResponse(responseCode = "404", description = "Curso não encontrado"),
             @ApiResponse(responseCode = "500", description = "Erro interno do servidor")
     })
-    ResponseEntity<Courses> update(Integer id, RequestCourseDTO course);
+    ResponseEntity<ResponseCourseDTO> update(Integer id, RequestCourseDTO course);
 
     @Operation(summary = "Remove um curso do sistema")
     @ApiResponses(value = {

--- a/src/main/java/br/com/ifrn/AcademicService/controller/docs/StudentPerformanceControllerDocs.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/docs/StudentPerformanceControllerDocs.java
@@ -1,6 +1,7 @@
 package br.com.ifrn.AcademicService.controller.docs;
 
 import br.com.ifrn.AcademicService.dto.request.RequestStudentPerformanceDTO;
+import br.com.ifrn.AcademicService.dto.request.RequestStudentPerformanceUpdateDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseClassEvaluationsDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseStudentPerformanceDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseclassificationsClassDTO;
@@ -75,6 +76,6 @@ public interface StudentPerformanceControllerDocs {
     })
     public ResponseEntity<ResponseStudentPerformanceDTO> updateStudentEvaluation(
             @PathVariable Integer id,
-            @RequestBody RequestStudentPerformanceDTO dto
+            @RequestBody RequestStudentPerformanceUpdateDTO dto
     );
 }

--- a/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestClassDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestClassDTO.java
@@ -1,5 +1,6 @@
 package br.com.ifrn.AcademicService.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -12,11 +13,7 @@ public class RequestClassDTO implements Serializable {
 
     @NotNull
     @Size(min = 1, max = 100)
-    private String name;
-
-    @NotNull
-    @Size(min = 1, max = 100)
-    private String semester;
+    private String gradleLevel;
 
     @NotNull
     @Size(min = 1, max = 100)

--- a/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestCommentDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestCommentDTO.java
@@ -1,5 +1,6 @@
 package br.com.ifrn.AcademicService.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -13,7 +14,7 @@ import java.io.Serializable;
 @AllArgsConstructor
 @NoArgsConstructor
 public class RequestCommentDTO implements Serializable {
-    @NotNull
-    @Size(min = 1, max = 1000)
+    @NotBlank(message = "Comentário não pode ser vazio ou nulo")
+    @Size(min = 1, max = 255, message = "Comentário não pode exceder 255 caracteres")
     private String comment;
 }

--- a/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestStudentPerformanceUpdateDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/request/RequestStudentPerformanceUpdateDTO.java
@@ -1,0 +1,16 @@
+package br.com.ifrn.AcademicService.dto.request;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter @Setter
+public class RequestStudentPerformanceUpdateDTO implements Serializable {
+    private float averageScore;
+    private float attendenceRate;
+    private Integer failedSubjects;
+    private float ira;
+    private Integer totalLowGrades;
+}

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassByIdDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassByIdDTO.java
@@ -14,8 +14,8 @@ public class ResponseClassByIdDTO {
     private String semester;
     private int gradleLevel;
     private String shift;
-    private Courses course;
-    private List<ResponseCommentDTO> comments;
+    private ResponseCourseDTO course;
+    //private List<ResponseCommentDTO> comments;
     private String classId;
     private List<StudentDataDTO> students;
 }

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassByIdDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassByIdDTO.java
@@ -11,7 +11,6 @@ import java.util.List;
 public class ResponseClassByIdDTO {
     private int id;
     private String name;
-    private String semester;
     private int gradleLevel;
     private String shift;
     private ResponseCourseDTO course;

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassDTO.java
@@ -15,8 +15,8 @@ public class ResponseClassDTO implements Serializable {
     private String name;
     private String semester;
     private String shift;
-    private Courses course;
-    private List<ClassComments> comments;
-    private List<String> userId;
+    private ResponseCourseDTO course;
+    //private List<ResponseCommentDTO> comments;
+    //private List<String> userId;
     private String classId;
 }

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassDTO.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class ResponseClassDTO implements Serializable {
     private int id;
     private String name;
-    private String semester;
+    private String gradleLevel;
     private String shift;
     private ResponseCourseDTO course;
     //private List<ResponseCommentDTO> comments;

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassEvaluationsDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseClassEvaluationsDTO.java
@@ -14,7 +14,7 @@ public class ResponseClassEvaluationsDTO implements Serializable {
     private Integer id;
     private String classId;
     private String professorId;
-    @JsonFormat(pattern = "yyyy-MM-dd")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd MMM. 'de' yyyy", locale = "pt-BR")
     @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate date;
     private float averageScore;

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseCommentDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseCommentDTO.java
@@ -18,4 +18,8 @@ public class ResponseCommentDTO implements Serializable {
     @JsonSerialize(using = LocalDateSerializer.class)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd MMM. 'de' yyyy", locale = "pt-BR")
     private LocalDate createdAt;
+
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd MMM. 'de' yyyy", locale = "pt-BR")
+    private LocalDate updatedAt;
 }

--- a/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseStudentPerformanceDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/response/ResponseStudentPerformanceDTO.java
@@ -1,6 +1,7 @@
 package br.com.ifrn.AcademicService.dto.response;
 
 import br.com.ifrn.AcademicService.models.enums.Status;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,6 +9,7 @@ import java.io.Serializable;
 
 @Getter @Setter
 public class ResponseStudentPerformanceDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
     private Integer id;
     private String studentId;
     private String classId;

--- a/src/main/java/br/com/ifrn/AcademicService/mapper/ClassMapper.java
+++ b/src/main/java/br/com/ifrn/AcademicService/mapper/ClassMapper.java
@@ -1,5 +1,6 @@
 package br.com.ifrn.AcademicService.mapper;
 
+import br.com.ifrn.AcademicService.dto.request.RequestClassDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseClassByIdDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseClassDTO;
 import br.com.ifrn.AcademicService.models.Classes;
@@ -9,8 +10,11 @@ import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface ClassMapper {
-
     ResponseClassByIdDTO toResponseClassByDTO(Classes classes);
-
     List<ResponseClassDTO> toResponseClassDTO(List<Classes> classes);
+    RequestClassDTO toRequestClassDTO(Classes classes);
+    List<RequestClassDTO> toRequestClassDTO(List<Classes> classes);
+    Classes toClassDTO(RequestClassDTO requestClassDTO);
+    List<Classes> toClassDTOList(List<RequestClassDTO> requestClassDTOs);
+    ResponseClassDTO toResponseClassDTO(Classes classes);
 }

--- a/src/main/java/br/com/ifrn/AcademicService/mapper/CommentsMapper.java
+++ b/src/main/java/br/com/ifrn/AcademicService/mapper/CommentsMapper.java
@@ -1,0 +1,15 @@
+package br.com.ifrn.AcademicService.mapper;
+
+import br.com.ifrn.AcademicService.dto.request.RequestCommentDTO;
+import br.com.ifrn.AcademicService.dto.response.ResponseClassDTO;
+import br.com.ifrn.AcademicService.dto.response.ResponseCommentDTO;
+import br.com.ifrn.AcademicService.models.ClassComments;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CommentsMapper {
+    ClassComments toClassComments(ResponseClassDTO classesDTO);
+    ResponseCommentDTO toResponseClassCommentsDTO(ClassComments classComments);
+    ClassComments toClassComments(ClassComments classComments);
+    RequestCommentDTO  toRequestCommentDTO(ClassComments classComments);
+}

--- a/src/main/java/br/com/ifrn/AcademicService/mapper/CoursesMapper.java
+++ b/src/main/java/br/com/ifrn/AcademicService/mapper/CoursesMapper.java
@@ -1,0 +1,15 @@
+package br.com.ifrn.AcademicService.mapper;
+
+import br.com.ifrn.AcademicService.dto.request.RequestCourseDTO;
+import br.com.ifrn.AcademicService.dto.response.ResponseCourseDTO;
+import br.com.ifrn.AcademicService.models.Courses;
+import org.mapstruct.Mapper;
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface CoursesMapper {
+    List<ResponseCourseDTO> toResponseCourseDTO(List<Courses> courses);
+    ResponseCourseDTO toResponseCourseDTO(Courses courses);
+    Courses toCourses(ResponseCourseDTO responseCourseDTO);
+    RequestCourseDTO toRequestCourseDTO(Courses courses);
+}

--- a/src/main/java/br/com/ifrn/AcademicService/mapper/StudentPerformanceMapper.java
+++ b/src/main/java/br/com/ifrn/AcademicService/mapper/StudentPerformanceMapper.java
@@ -3,6 +3,7 @@ package br.com.ifrn.AcademicService.mapper;
 
 import br.com.ifrn.AcademicService.dto.ImportMessageDTO;
 import br.com.ifrn.AcademicService.dto.request.RequestStudentPerformanceDTO;
+import br.com.ifrn.AcademicService.dto.request.RequestStudentPerformanceUpdateDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseStudentPerformanceDTO;
 import br.com.ifrn.AcademicService.dto.response.StudentDataDTO;
 import br.com.ifrn.AcademicService.models.StudentPerformance;
@@ -31,11 +32,12 @@ public interface StudentPerformanceMapper {
     @Mapping(source = "ira", target = "ira")
     RequestStudentPerformanceDTO toRequestStudentPerformanceByConsumerMessageDto (ImportMessageDTO dto);
 
+    RequestStudentPerformanceUpdateDTO toRequestStudentPerformanceUpdateDto (RequestStudentPerformanceDTO entity);
+
     @Mapping(source = "failedSubjects", target = "failedSubjects")
     //@Mapping(source = "averageScore", target = "averageScore")
     @Mapping(source = "attendenceRate", target = "attendenceRate")
     @Mapping(source = "ira", target = "ira")
-    @Mapping(source = "classId", target = "classId")
-    void updateEntityFromDto(RequestStudentPerformanceDTO dto,
+    void updateEntityFromDto(RequestStudentPerformanceUpdateDTO dto,
                              @MappingTarget StudentPerformance entity);
 }

--- a/src/main/java/br/com/ifrn/AcademicService/models/Classes.java
+++ b/src/main/java/br/com/ifrn/AcademicService/models/Classes.java
@@ -24,6 +24,7 @@ public class Classes {
     @Column(name = "name",  nullable = false,  length = 255)
     private String name;
     private String shift;
+    private String gradleLevel;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", nullable = false)

--- a/src/main/java/br/com/ifrn/AcademicService/models/enums/Status.java
+++ b/src/main/java/br/com/ifrn/AcademicService/models/enums/Status.java
@@ -1,8 +1,10 @@
 package br.com.ifrn.AcademicService.models.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Status {
+
     OPTIMO("Ótimo"),
     BOM("Bom"),
     RUIM("Ruim");
@@ -13,8 +15,18 @@ public enum Status {
         this.descricao = descricao;
     }
 
-    @JsonValue // Faz com que o JSON retorne "Ótimo" em vez de "OPTIMO"
+    @JsonValue
     public String getDescricao() {
         return descricao;
+    }
+
+    @JsonCreator
+    public static Status fromValue(String value) {
+        for (Status status : Status.values()) {
+            if (status.descricao.equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Status inválido: " + value);
     }
 }

--- a/src/main/java/br/com/ifrn/AcademicService/repository/ClassEvaluationsRepository.java
+++ b/src/main/java/br/com/ifrn/AcademicService/repository/ClassEvaluationsRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ClassEvaluationsRepository extends JpaRepository<ClassEvaluations, Integer> {
-    List<ClassEvaluations> findByClassId(Integer classId);
+    List<ClassEvaluations> findByClassId(String classId);
     @Query("SELECT AVG(c.frequencyScore) as avgFrequency, AVG(c.unifirmScore) as avgUniform, " +
             "AVG(c.behaviorScore) as avgBehavior, AVG(c.participationScore) as avgParticipation, " +
             "AVG(c.performanceScore) as avgPerformance, AVG(c.cellPhoneUseScore) as avgCellPhone, " +

--- a/src/main/java/br/com/ifrn/AcademicService/repository/ClassesRepository.java
+++ b/src/main/java/br/com/ifrn/AcademicService/repository/ClassesRepository.java
@@ -9,6 +9,9 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface ClassesRepository extends JpaRepository<Classes, Integer> {
+    @Query("SELECT c FROM Classes c JOIN FETCH c.course")
+    List<Classes> findAllWithCourse();
+
     Classes findByClassId(String classId);
 
     List<Classes> findByCourse(Courses course);

--- a/src/main/java/br/com/ifrn/AcademicService/repository/StudentPerformanceRepository.java
+++ b/src/main/java/br/com/ifrn/AcademicService/repository/StudentPerformanceRepository.java
@@ -3,6 +3,9 @@ package br.com.ifrn.AcademicService.repository;
 import br.com.ifrn.AcademicService.models.StudentPerformance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface StudentPerformanceRepository extends JpaRepository<StudentPerformance, Integer> {
     StudentPerformance findStudentPerformanceByStudentId(String studentId);
+    List<StudentPerformance> findByStudentIdIn(List<String> studentIds);
 }

--- a/src/main/java/br/com/ifrn/AcademicService/services/ClassCommentsService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/ClassCommentsService.java
@@ -3,6 +3,7 @@ package br.com.ifrn.AcademicService.services;
 import br.com.ifrn.AcademicService.config.keycloak.KeycloakAdminConfig;
 import br.com.ifrn.AcademicService.dto.request.RequestCommentDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseCommentDTO;
+import br.com.ifrn.AcademicService.mapper.CommentsMapper;
 import br.com.ifrn.AcademicService.models.ClassComments;
 import br.com.ifrn.AcademicService.models.Classes;
 import br.com.ifrn.AcademicService.repository.ClassCommentsRepository;
@@ -14,8 +15,6 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +31,9 @@ public class ClassCommentsService {
 
     @Autowired
     private ClassesRepository classesRepository;
+
+    @Autowired
+    private CommentsMapper  commentsMapper;
 
     @Cacheable(value = "commentsCache", key = "#turmaId")
     public List<ResponseCommentDTO> getByTurma(Integer turmaId) {
@@ -51,16 +53,7 @@ public class ClassCommentsService {
     }
 
     @CacheEvict(value = "commentsCache", allEntries = true)
-    public ClassComments create(RequestCommentDTO commentDTO, String professorId, Integer classId) {
-        if (commentDTO.getComment() == null) {
-            throw new IllegalArgumentException("Comentário não pode ser nulo");
-        }
-        if (commentDTO.getComment().trim().isEmpty()) {
-            throw new IllegalArgumentException("Comentário não pode ser vazio");
-        }
-        if (commentDTO.getComment().length() > 255) {
-            throw new IllegalArgumentException("Comentário não pode exceder 255 caracteres");
-        }
+    public ResponseCommentDTO create(RequestCommentDTO commentDTO, String professorId, Integer classId) {
         if (professorId == null || professorId.trim().isEmpty()) {
             throw new IllegalArgumentException("Professor ID inválido!");
         }
@@ -76,16 +69,18 @@ public class ClassCommentsService {
         } catch (Exception e) {
             throw new RuntimeException("Erro ao buscar dados do professor", e);
         }
-        return commentRepository.save(classComments);
+        return commentsMapper.toResponseClassCommentsDTO(commentRepository.save(classComments));
     }
 
     @CacheEvict(value = "commentsCache", allEntries = true)
-    public ClassComments update(ClassComments comment) {
-        ClassComments classComment = commentRepository.findById(comment.getId())
+    public ResponseCommentDTO update(Integer commentId,  RequestCommentDTO comment, String professorId) throws IllegalAccessException {
+        ClassComments classComment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ccomentário não encontrado!"));
-        classComment.setComment(comment.getComment());
-        classComment.setUpdatedAt(comment.getUpdatedAt());
-        return commentRepository.save(classComment);
+        if (classComment.getProfessorId().equals(professorId)) {
+            classComment.setComment(comment.getComment());
+        }else throw new IllegalAccessException("O comentário só pode ser alterado pelo usuário de criação!");
+
+        return commentsMapper.toResponseClassCommentsDTO(commentRepository.save(classComment));
     }
 
     @CacheEvict(value = "commentsCache", allEntries = true)

--- a/src/main/java/br/com/ifrn/AcademicService/services/ClassEvaluationsService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/ClassEvaluationsService.java
@@ -4,8 +4,10 @@ import br.com.ifrn.AcademicService.dto.request.RequestClassEvaluationsDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseClassEvaluationsDTO;
 import br.com.ifrn.AcademicService.mapper.EvaluationsMapper;
 import br.com.ifrn.AcademicService.models.ClassEvaluations;
+import br.com.ifrn.AcademicService.models.Classes;
 import br.com.ifrn.AcademicService.models.EvaluationsCriteria;
 import br.com.ifrn.AcademicService.repository.ClassEvaluationsRepository;
+import br.com.ifrn.AcademicService.repository.ClassesRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -24,6 +26,9 @@ public class ClassEvaluationsService {
 
     @Autowired
     EvaluationsMapper evaluationsMapper;
+
+    @Autowired
+    ClassesRepository classesRepository;
 
     @Cacheable(value = "evaluationsCacheAll")
     public List<ResponseClassEvaluationsDTO> getAllEvaluations() {
@@ -51,7 +56,8 @@ public class ClassEvaluationsService {
 
     @Cacheable(value = "evaluationsCacheByClass", key = "#id")
     public List<ResponseClassEvaluationsDTO> getEvaluationsByClassId(Integer id) {
-        List<ClassEvaluations> classEvaluations = classEvaluationsRepository.findByClassId(id);
+        Classes classes = classesRepository.findById(id).orElseThrow(() -> new NoSuchElementException("Class not found"));
+        List<ClassEvaluations> classEvaluations = classEvaluationsRepository.findByClassId(classes.getClassId());
         List<ResponseClassEvaluationsDTO> responseDTO = classEvaluations
                 .stream()
                 .map(evaluationsMapper::toResponseClassEvaluationsDTO)

--- a/src/main/java/br/com/ifrn/AcademicService/services/ClassEvaluationsService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/ClassEvaluationsService.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/br/com/ifrn/AcademicService/services/StudentPerformanceService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/StudentPerformanceService.java
@@ -2,6 +2,7 @@ package br.com.ifrn.AcademicService.services;
 
 import br.com.ifrn.AcademicService.dto.ImportMessageDTO;
 import br.com.ifrn.AcademicService.dto.request.RequestStudentPerformanceDTO;
+import br.com.ifrn.AcademicService.dto.request.RequestStudentPerformanceUpdateDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseStudentPerformanceDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseclassificationsClassDTO;
 import br.com.ifrn.AcademicService.mapper.StudentPerformanceMapper;
@@ -126,14 +127,18 @@ public class StudentPerformanceService {
 
     @CacheEvict(value = "studentPerformanceCacheAll", allEntries = true)
     public ResponseStudentPerformanceDTO createStudentPerformance(RequestStudentPerformanceDTO requestDTO) {
-        StudentPerformance studentPerformance = mapper.toEntity(requestDTO);
+        StudentPerformance studentPerformance = studentPerformanceRepository.findStudentPerformanceByStudentId(requestDTO.getStudentId());
+        if (studentPerformance != null) {
+            throw  new EntityNotFoundException("Já existe uma avaliação cadastrada para esse aluno!");
+        }
+        studentPerformance = mapper.toEntity(requestDTO);
         studentPerformance = studentPerformanceRepository.save(studentPerformance);
         ResponseStudentPerformanceDTO responseDto = mapper.toResponseDto(studentPerformance);
         return responseDto;
     }
 
     @CacheEvict(value = {"studentPerformanceCache", "studentPerformanceCacheAll"}, allEntries = true)
-    public ResponseStudentPerformanceDTO updateStudentPerformance(Integer id, RequestStudentPerformanceDTO dto) {
+    public ResponseStudentPerformanceDTO updateStudentPerformance(Integer id, RequestStudentPerformanceUpdateDTO dto) {
         StudentPerformance studentPerformance = studentPerformanceRepository.findById(id)
                 .orElseThrow(()-> new EntityNotFoundException("Not found Student Performance by Id: " + id));
         mapper.updateEntityFromDto(dto, studentPerformance);
@@ -155,7 +160,7 @@ public class StudentPerformanceService {
         if (studentPerformance == null) {
             responseDto = createStudentPerformance(studentPerformanceDTO);
         }else{
-            responseDto = updateStudentPerformance(studentPerformance.getId(), studentPerformanceDTO);
+            responseDto = updateStudentPerformance(studentPerformance.getId(), mapper.toRequestStudentPerformanceUpdateDto(studentPerformanceDTO));
         }
         return responseDto;
     }

--- a/src/test/java/br/com/ifrn/AcademicService/ClassCommentsServiceTest.java
+++ b/src/test/java/br/com/ifrn/AcademicService/ClassCommentsServiceTest.java
@@ -3,6 +3,7 @@ package br.com.ifrn.AcademicService;
 import br.com.ifrn.AcademicService.config.keycloak.KeycloakAdminConfig;
 import br.com.ifrn.AcademicService.dto.request.RequestCommentDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseCommentDTO;
+import br.com.ifrn.AcademicService.mapper.CommentsMapper;
 import br.com.ifrn.AcademicService.models.ClassComments;
 import br.com.ifrn.AcademicService.models.Classes;
 import br.com.ifrn.AcademicService.repository.ClassCommentsRepository;
@@ -17,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -41,6 +43,9 @@ class ClassCommentsServiceTest {
 
     @Mock
     private ClassesRepository classesRepository;
+
+    @Autowired
+    private CommentsMapper  commentsMapper;
 
     @InjectMocks
     private ClassCommentsService commentService;
@@ -109,12 +114,11 @@ class ClassCommentsServiceTest {
         when(commentsRepository.save(any(ClassComments.class))).thenAnswer(i -> i.getArguments()[0]);
 
         // Act
-        ClassComments created = commentService.create(dto, profId, classId);
+        ResponseCommentDTO created = commentService.create(dto, profId, classId);
 
         // Assert
         assertNotNull(created);
         assertEquals("Excelente participação", created.getComment());
-        assertEquals(profId, created.getProfessorId());
         assertEquals("Professor Girafales", created.getProfessorName());
         verify(commentsRepository, times(1)).save(any(ClassComments.class));
     }
@@ -181,7 +185,7 @@ class ClassCommentsServiceTest {
     }
 
     @Test
-    void update_quandoExiste_deveAtualizarCamposESalvar() {
+    void update_quandoExiste_deveAtualizarCamposESalvar() throws IllegalAccessException {
         ClassComments existing = new ClassComments();
         existing.setId(1);
         existing.setProfessorId("professorId");
@@ -189,18 +193,15 @@ class ClassCommentsServiceTest {
         existing.setUpdatedAt(LocalDate.of(2026, 1, 1));
         existing.setClasse(classe);
 
-        ClassComments incoming = new ClassComments();
-        incoming.setId(1);
+        RequestCommentDTO incoming = new RequestCommentDTO();
         incoming.setComment("Novo comentário");
-        incoming.setUpdatedAt(LocalDate.of(2026, 1, 27));
 
         when(commentsRepository.findById(1)).thenReturn(Optional.of(existing));
         when(commentsRepository.save(any(ClassComments.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        ClassComments updated = commentService.update(incoming);
+        ResponseCommentDTO updated = commentService.update(1, incoming, "professorId");
 
         assertEquals("Novo comentário", updated.getComment());
-        assertEquals(LocalDate.of(2026, 1, 27), updated.getUpdatedAt());
 
         ArgumentCaptor<ClassComments> captor = ArgumentCaptor.forClass(ClassComments.class);
         verify(commentsRepository).findById(1);
@@ -214,7 +215,7 @@ class ClassCommentsServiceTest {
         when(commentsRepository.findById(1)).thenReturn(Optional.empty());
 
         ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-                () -> commentService.update(comment));
+                () -> commentService.update(1, commentsMapper.toRequestCommentDTO(comment), "professorId"));
 
         assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
         // mensagem do service está "Ccomentário..." (com C duplicado). O teste garante o comportamento atual:

--- a/src/test/java/br/com/ifrn/AcademicService/ClassEvaluationsServiceTest.java
+++ b/src/test/java/br/com/ifrn/AcademicService/ClassEvaluationsServiceTest.java
@@ -98,7 +98,7 @@ class ClassEvaluationsServiceTest {
 
     @Test
     void getEvaluationsByClassIdShouldMapEntityList() {
-        when(classEvaluationsRepository.findByClassId(10))
+        when(classEvaluationsRepository.findByClassId("classId"))
                 .thenReturn(List.of(entity1, entity2));
 
         ResponseClassEvaluationsDTO dto1 = mock(ResponseClassEvaluationsDTO.class);
@@ -111,7 +111,7 @@ class ClassEvaluationsServiceTest {
                 service.getEvaluationsByClassId(10);
 
         assertEquals(2, result.size());
-        verify(classEvaluationsRepository).findByClassId(10);
+        verify(classEvaluationsRepository).findByClassId("classId");
         verify(evaluationsMapper).toResponseClassEvaluationsDTO(entity1);
         verify(evaluationsMapper).toResponseClassEvaluationsDTO(entity2);
         verifyNoMoreInteractions(classEvaluationsRepository, evaluationsMapper);

--- a/src/test/java/br/com/ifrn/AcademicService/ClassesServiceTest.java
+++ b/src/test/java/br/com/ifrn/AcademicService/ClassesServiceTest.java
@@ -75,7 +75,7 @@ class ClassesServiceTest {
     void testCreate() {
         when(classesRepository.save(any(Classes.class))).thenReturn(turma);
 
-        Classes created = classesService.create(turma);
+        ResponseClassDTO created = classesService.create(turma.getCourse().getId(), classsMapper.toRequestClassDTO(turma));
 
         assertNotNull(created);
         assertEquals("Matemática", created.getName());
@@ -129,7 +129,7 @@ class ClassesServiceTest {
         when(classesRepository.findById(1)).thenReturn(Optional.of(turma));
         when(classesRepository.save(any(Classes.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        Classes result = classesService.update(1, updated);
+        ResponseClassDTO result = classesService.update(1, turma.getCourse().getId(), classsMapper.toRequestClassDTO(turma));
 
         assertEquals("Física", result.getName());
         verify(classesRepository).save(any(Classes.class));
@@ -140,7 +140,7 @@ class ClassesServiceTest {
         when(classesRepository.findById(1)).thenReturn(Optional.empty());
 
         EntityNotFoundException ex = assertThrows(EntityNotFoundException.class, () -> {
-            classesService.update(1, turma);
+            classesService.update(1, turma.getCourse().getId(), classsMapper.toRequestClassDTO(turma));
         });
 
         assertEquals("Classe not found", ex.getMessage());
@@ -176,7 +176,7 @@ class ClassesServiceTest {
         turma.setName("");
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            classesService.create(turma);
+            classesService.create(turma.getCourse().getId(), classsMapper.toRequestClassDTO(turma));
         });
 
         assertEquals("Nome da turma não pode ser vazio", exception.getMessage());
@@ -187,7 +187,7 @@ class ClassesServiceTest {
         turma.setName(null);
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            classesService.create(turma);
+            classesService.create(turma.getCourse().getId(), classsMapper.toRequestClassDTO(turma));
         });
 
         assertEquals("Nome da turma não pode ser nulo", exception.getMessage());
@@ -198,7 +198,7 @@ class ClassesServiceTest {
         turma.setName("A".repeat(256));
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            classesService.create(turma);
+            classesService.create(turma.getCourse().getId(), classsMapper.toRequestClassDTO(turma));
         });
 
         assertEquals("Nome da turma não pode exceder 255 caracteres", exception.getMessage());

--- a/src/test/java/br/com/ifrn/AcademicService/ClassesServiceTest.java
+++ b/src/test/java/br/com/ifrn/AcademicService/ClassesServiceTest.java
@@ -9,6 +9,7 @@ import br.com.ifrn.AcademicService.mapper.StudentPerformanceMapper;
 import br.com.ifrn.AcademicService.models.Classes;
 import br.com.ifrn.AcademicService.models.Courses;
 import br.com.ifrn.AcademicService.repository.ClassesRepository;
+import br.com.ifrn.AcademicService.repository.StudentPerformanceRepository;
 import br.com.ifrn.AcademicService.services.ClassesService;
 import br.com.ifrn.AcademicService.services.CoursesService;
 import br.com.ifrn.AcademicService.services.StudentPerformanceService;
@@ -44,6 +45,9 @@ class ClassesServiceTest {
 
     @Mock
     private StudentPerformanceService studentPerformanceService;
+
+    @Mock
+    private StudentPerformanceRepository studentPerformanceRepository;
 
     @Mock
     private StudentPerformanceMapper studentPerformanceMapper;
@@ -86,7 +90,8 @@ class ClassesServiceTest {
         ResponseClassDTO turmaDTO = new ResponseClassDTO();
         turmaDTO.setName("Matemática");
 
-        when(classesRepository.findAll()).thenReturn(List.of(turmaEntity));
+        when(classesRepository.findAllWithCourse()).thenReturn(List.of(turmaEntity));
+
         when(classsMapper.toResponseClassDTO(anyList())).thenReturn(List.of(turmaDTO));
 
         List<ResponseClassDTO> all = classesService.getAll();
@@ -97,7 +102,7 @@ class ClassesServiceTest {
 
     @Test
     void testGetAllWhenEmpty() {
-        when(classesRepository.findAll()).thenReturn(List.of());
+        when(classesRepository.findAllWithCourse()).thenReturn(List.of());
         when(classsMapper.toResponseClassDTO(anyList())).thenReturn(List.of());
 
         List<ResponseClassDTO> all = classesService.getAll();
@@ -268,8 +273,8 @@ class ClassesServiceTest {
         when(classesRepository.findById(1)).thenReturn(Optional.of(c));
         when(classsMapper.toResponseClassByDTO(c)).thenReturn(dto);
 
-        when(keycloakAdminConfig.findKeycloakUser("u1")).thenReturn(null);
-
+        when(keycloakAdminConfig.findKeycloakUsersByIds(anyList())).thenReturn(new ArrayList<>());
+        when(studentPerformanceRepository.findByStudentIdIn(anyList())).thenReturn(new ArrayList<>());
         ResponseClassByIdDTO result = classesService.getByClassId(1);
 
         assertNotNull(result.getStudents());
@@ -279,32 +284,27 @@ class ClassesServiceTest {
 
     @Test
     void testGetByClassIdUserFoundShouldAddStudent() throws Exception {
-        Classes c = new Classes();
-        c.setId(1);
-        c.setName("Turma X");
-        c.setUserId(List.of("u1"));
-
-        ResponseClassByIdDTO dto = new ResponseClassByIdDTO();
+        Integer id = 1;
+        Classes classe = new Classes();
+        classe.setUserId(List.of("aluno-uuid-123"));
 
         UserRepresentation user = new UserRepresentation();
-        user.setId("kc-1");
-        user.setFirstName("Marcos");
-        user.setUsername("20241094040001");
+        user.setId("aluno-uuid-123");
+        user.setFirstName("Eduardo");
+        user.setUsername("202612345");
 
-        StudentDataDTO mappedStudent = new StudentDataDTO();
+        when(keycloakAdminConfig.findKeycloakUsersByIds(anyList()))
+                .thenReturn(List.of(user));
 
-        when(classesRepository.findById(1)).thenReturn(Optional.of(c));
-        when(classsMapper.toResponseClassByDTO(c)).thenReturn(dto);
+        when(studentPerformanceRepository.findByStudentIdIn(anyList()))
+                .thenReturn(new ArrayList<>());
 
-        when(keycloakAdminConfig.findKeycloakUser("u1")).thenReturn(user);
-        when(studentPerformanceService.getStudentPerformanceByStudentId("kc-1")).thenReturn(null);
-        when(studentPerformanceMapper.toStudentDataDTO(any())).thenReturn(mappedStudent);
+        when(classesRepository.findById(id)).thenReturn(Optional.of(classe));
+        when(classsMapper.toResponseClassByDTO(any())).thenReturn(new ResponseClassByIdDTO());
 
-        ResponseClassByIdDTO result = classesService.getByClassId(1);
+        ResponseClassByIdDTO result = classesService.getByClassId(id);
 
         assertEquals(1, result.getStudents().size());
-        assertEquals("Marcos", result.getStudents().get(0).getName());
-        assertEquals("20241094040001", result.getStudents().get(0).getRegistration());
     }
 
     // ==============================

--- a/src/test/java/br/com/ifrn/AcademicService/CoursesServiceTest.java
+++ b/src/test/java/br/com/ifrn/AcademicService/CoursesServiceTest.java
@@ -1,5 +1,8 @@
 package br.com.ifrn.AcademicService;
 
+import br.com.ifrn.AcademicService.dto.request.RequestCourseDTO;
+import br.com.ifrn.AcademicService.dto.response.ResponseCourseDTO;
+import br.com.ifrn.AcademicService.mapper.CoursesMapper;
 import br.com.ifrn.AcademicService.models.Courses;
 import br.com.ifrn.AcademicService.repository.CoursesRepository;
 import br.com.ifrn.AcademicService.services.CoursesService;
@@ -8,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
@@ -25,6 +29,9 @@ class CoursesServiceTest {
     @InjectMocks
     private CoursesService coursesService;
 
+    @Autowired
+    CoursesMapper coursesMapper;
+
     private Courses course;
 
     @BeforeEach
@@ -39,8 +46,9 @@ class CoursesServiceTest {
     void testCreate() {
         when(coursesRepository.findByName(course.getName())).thenReturn(null);
         when(coursesRepository.save(any(Courses.class))).thenReturn(course);
+        RequestCourseDTO  requestCourseDTO = coursesMapper.toRequestCourseDTO(course);
 
-        Courses created = coursesService.create(course);
+        ResponseCourseDTO created = coursesService.create(requestCourseDTO);
 
         assertNotNull(created);
         assertEquals("Análise de Sistemas", created.getName());
@@ -50,7 +58,7 @@ class CoursesServiceTest {
     void testGetAll() {
         when(coursesRepository.findAll()).thenReturn(List.of(course));
 
-        List<Courses> all = coursesService.getAll();
+        List<ResponseCourseDTO> all = coursesService.getAll();
 
         assertEquals(1, all.size());
     }
@@ -59,9 +67,9 @@ class CoursesServiceTest {
     void testGetById() {
         when(coursesRepository.findById(1)).thenReturn(Optional.of(course));
 
-        Optional<Courses> result = coursesService.getById(1);
+        ResponseCourseDTO result = coursesService.getById(1);
 
-        assertTrue(result.isPresent());
+        assertTrue(result != null);
     }
 
     @Test
@@ -69,6 +77,7 @@ class CoursesServiceTest {
         // GIVEN
         Courses updatedDetails = new Courses();
         updatedDetails.setName("Informática"); // Nome válido, não lança erro!
+        RequestCourseDTO requestCourseDTO = coursesMapper.toRequestCourseDTO(updatedDetails);
 
         // "turma" ou "course" (o que está no banco)
         Courses courseInDb = new Courses();
@@ -79,7 +88,7 @@ class CoursesServiceTest {
         when(coursesRepository.save(any(Courses.class))).thenAnswer(i -> i.getArgument(0));
 
         // WHEN
-        Courses result = coursesService.update(1, updatedDetails);
+        ResponseCourseDTO result = coursesService.update(1, requestCourseDTO);
 
         // THEN
         assertEquals("Informática", result.getName());
@@ -109,7 +118,7 @@ class CoursesServiceTest {
         course.setName("");
 
         assertThrows(IllegalArgumentException.class,
-                () -> coursesService.create(course));
+                () -> coursesService.create(coursesMapper.toRequestCourseDTO(course)));
     }
 
     @Test
@@ -117,7 +126,7 @@ class CoursesServiceTest {
         course.setName(null);
 
         assertThrows(IllegalArgumentException.class,
-                () -> coursesService.create(course));
+                () -> coursesService.create(coursesMapper.toRequestCourseDTO(course)));
 
         verify(coursesRepository, never()).save(any());
     }
@@ -127,7 +136,7 @@ class CoursesServiceTest {
         course.setName(null);
 
         assertThrows(IllegalArgumentException.class,
-                () -> coursesService.update(1, course));
+                () -> coursesService.update(1, coursesMapper.toRequestCourseDTO(course)));
     }
 
     @Test
@@ -135,7 +144,7 @@ class CoursesServiceTest {
         course.setName("");
 
         assertThrows(IllegalArgumentException.class,
-                () -> coursesService.update(1, course));
+                () -> coursesService.update(1, coursesMapper.toRequestCourseDTO(course)));
     }
 
     @Test
@@ -143,7 +152,7 @@ class CoursesServiceTest {
         course.setName("A".repeat(256));
 
         assertThrows(IllegalArgumentException.class,
-                () -> coursesService.update(1, course));
+                () -> coursesService.update(1, coursesMapper.toRequestCourseDTO(course)));
     }
 
     @Test
@@ -151,7 +160,7 @@ class CoursesServiceTest {
         when(coursesRepository.findById(1)).thenReturn(Optional.empty());
 
         assertThrows(RuntimeException.class,
-                () -> coursesService.update(1, course));
+                () -> coursesService.update(1, coursesMapper.toRequestCourseDTO(course)));
     }
 
     @Test

--- a/src/test/java/br/com/ifrn/AcademicService/StudentPerformanceServiceTest.java
+++ b/src/test/java/br/com/ifrn/AcademicService/StudentPerformanceServiceTest.java
@@ -2,6 +2,7 @@ package br.com.ifrn.AcademicService;
 
 import br.com.ifrn.AcademicService.dto.ImportMessageDTO;
 import br.com.ifrn.AcademicService.dto.request.RequestStudentPerformanceDTO;
+import br.com.ifrn.AcademicService.dto.request.RequestStudentPerformanceUpdateDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseStudentPerformanceDTO;
 import br.com.ifrn.AcademicService.mapper.StudentPerformanceMapper;
 import br.com.ifrn.AcademicService.models.StudentPerformance;
@@ -115,7 +116,7 @@ class StudentPerformanceServiceTest {
     void updateStudentPerformanceWhenExistsShouldUpdateSaveAndReturnDto() {
         when(repository.findById(1)).thenReturn(Optional.of(entity));
 
-        RequestStudentPerformanceDTO req = mock(RequestStudentPerformanceDTO.class);
+        RequestStudentPerformanceUpdateDTO req = mock(RequestStudentPerformanceUpdateDTO.class);
 
         // save é chamado 2x no código atual
         when(repository.save(entity)).thenReturn(entity);
@@ -138,7 +139,7 @@ class StudentPerformanceServiceTest {
         when(repository.findById(123)).thenReturn(Optional.empty());
 
         EntityNotFoundException ex = assertThrows(EntityNotFoundException.class,
-                () -> service.updateStudentPerformance(123, mock(RequestStudentPerformanceDTO.class)));
+                () -> service.updateStudentPerformance(123, mock(RequestStudentPerformanceUpdateDTO.class)));
 
         assertEquals("Not found Student Performance by Id: 123", ex.getMessage());
         verify(repository).findById(123);
@@ -173,9 +174,8 @@ class StudentPerformanceServiceTest {
     void createStudentPerformanceByConsumerMessageDTOWhenStudentExistsShouldUpdate() {
         ImportMessageDTO msg = mock(ImportMessageDTO.class);
 
-        RequestStudentPerformanceDTO req = mock(RequestStudentPerformanceDTO.class);
-        when(req.getStudentId()).thenReturn("S1");
-        when(mapper.toRequestStudentPerformanceByConsumerMessageDto(msg)).thenReturn(req);
+        RequestStudentPerformanceUpdateDTO req = mock(RequestStudentPerformanceUpdateDTO.class);
+        when(mapper.toRequestStudentPerformanceByConsumerMessageDto(msg)).thenReturn(mapper.toRequestStudentPerformanceByConsumerMessageDto(msg));
 
         StudentPerformance existing = new StudentPerformance();
         existing.setId(55);


### PR DESCRIPTION
- Redis: Unificação da configuração de serialização utilizando um ObjectMapper injetado,
  garantindo suporte a tipos polimórficos e módulos JavaTime em todos os caches.
- Security: Ativação de @EnableMethodSecurity e implementação de JwtAuthenticationConverter
  para extrair o claim customizado 'type_user' como GrantedAuthority.
- Keycloak: Adição de método para buscar membros de um grupo específico por nome.
- API/DTOs:
    - Padronização do retorno dos Controllers para ResponseDTOs em vez de Entities.
    - Atualização do modelo de 'Classes' para incluir 'gradleLevel' e remover 'semester'.
    - Implementação de validações via Bean Validation (@notblank, @SiZe) nos DTOs de comentário.
    - Criação de RequestStudentPerformanceUpdateDTO para operações de atualização de desempenho.
- Refatoração: Centralização da lógica de extração de Subject (professorId) no ClassCommentsController.