### PR TITLE
feat: refatorar métricas de desempenho e gestão de ciclos de avaliação

### DIFF
--- a/src/main/java/br/com/ifrn/AcademicService/controller/PainelControleController.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/PainelControleController.java
@@ -7,6 +7,7 @@ import br.com.ifrn.AcademicService.dto.response.ResponseProfessorPanelDTO;
 import br.com.ifrn.AcademicService.dto.response.StudentDataDTO;
 import br.com.ifrn.AcademicService.models.EvaluationPeriod;
 import br.com.ifrn.AcademicService.services.PainelControleService;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -31,13 +32,9 @@ public class PainelControleController implements PainelControleControllerDocs {
     }
 
     @PostMapping("/evaluation-periods/start")
-    public ResponseEntity<String> startNewEvaluationCycle(@RequestBody StartPeriodDTO dto) {
-        try {
-             painelControleService.startNewPeriod(dto);
-            return ResponseEntity.ok("Sucesso!");
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().body("ERRO: " + e.getMessage());
-        }
+    public ResponseEntity<String> startNewEvaluationCycle(@RequestBody @Valid StartPeriodDTO dto) {
+        painelControleService.startNewPeriod(dto);
+        return ResponseEntity.ok("Sucesso!");
     }
 
 

--- a/src/main/java/br/com/ifrn/AcademicService/controller/StudentPerformanceController.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/StudentPerformanceController.java
@@ -28,8 +28,8 @@ public class StudentPerformanceController implements StudentPerformanceControlle
     public ResponseEntity<List<ResponseStudentPerformanceDTO>> getAllStudentPerformance() {
         return ResponseEntity.ok().body(studentPerformanceService.getAllStudentPerformance());
     }
-    @GetMapping("/class/{id}/{year}/{bimestre}")
-    public ResponseEntity<ResponseclassificationsClassDTO> getClassEvaluationsById(@PathVariable Integer id, @PathVariable Integer year, @PathVariable StepName bimestre) {
+    @GetMapping("/class/{id}/{year}/bimestre/{bimestre}")
+    public ResponseEntity<ResponseclassificationsClassDTO> getClassEvaluationsById(@PathVariable Integer id, @PathVariable Integer year, @PathVariable Integer bimestre) {
         return ResponseEntity.ok().body(studentPerformanceService.getClassificationByClassId(id, year, bimestre));
     }
     @GetMapping("/class/all")

--- a/src/main/java/br/com/ifrn/AcademicService/controller/docs/PainelControleControllerDocs.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/docs/PainelControleControllerDocs.java
@@ -6,11 +6,13 @@ import br.com.ifrn.AcademicService.models.EvaluationPeriod;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import java.util.List;
 
@@ -31,14 +33,43 @@ public interface PainelControleControllerDocs {
             @ApiResponse(responseCode = "401", description = "Usuário não autenticado")
     })
     public ResponseEntity<List<StudentDataDTO>> getAllStudents();
-    @Operation(summary = "Inicia um novo ciclo de avaliação")
+
+    @Operation(
+            summary = "Inicia um novo ciclo de avaliação",
+            description = "Cria um novo período de avaliação (bimestre) para o ano informado. " +
+                    "Este método encerra automaticamente qualquer período anterior que esteja aberto."
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Novo período de avaliação iniciado com sucesso"),
-            @ApiResponse(responseCode = "400", description = "Dados da requisição inválidos (campos nulos ou incorretos)"),
-            @ApiResponse(responseCode = "422", description = "Regra de negócio violada (ex: já existe período ativo)"),
-            @ApiResponse(responseCode = "500", description = "Erro interno no servidor")
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Novo período de avaliação iniciado com sucesso"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Dados da requisição inválidos. Verifique se o ano é superior a 2024 e se o bimestre está correto."
+            ),
+            @ApiResponse(
+                    responseCode = "422",
+                    description = "Regra de negócio violada: Não é possível iniciar um período que já foi concluído ou erro na transição de ciclos."
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "Erro interno no servidor ao tentar persistir o novo ciclo."
+            )
     })
-    public ResponseEntity<String> startNewEvaluationCycle(@RequestBody StartPeriodDTO dto);
+    public ResponseEntity<String> startNewEvaluationCycle(
+            @RequestBody(
+                    description = "Dados para abertura do ciclo",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = StartPeriodDTO.class),
+                            examples = @ExampleObject(
+                                    value = "{ \"stepName\": \"PRIMEIRO\", \"year\": 2026 }"
+                            )
+                    )
+            )
+            @Valid StartPeriodDTO dto
+    );
 
     @Operation(summary = "Busca o período de avaliação atualmente ativo")
     @ApiResponses(value = {

--- a/src/main/java/br/com/ifrn/AcademicService/controller/docs/StudentPerformanceControllerDocs.java
+++ b/src/main/java/br/com/ifrn/AcademicService/controller/docs/StudentPerformanceControllerDocs.java
@@ -7,6 +7,7 @@ import br.com.ifrn.AcademicService.dto.response.ResponseStudentPerformanceDTO;
 import br.com.ifrn.AcademicService.dto.response.ResponseclassificationsClassDTO;
 import br.com.ifrn.AcademicService.models.enums.StepName;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,17 +39,32 @@ public interface StudentPerformanceControllerDocs {
 
     @Operation(
             summary = "Obter desempenho coletivo da turma",
-            description = "Retorna os indicadores de desempenho consolidados da turma com base nas avaliações registradas."
+            description = "Retorna os indicadores de desempenho consolidados de uma turma (médias de frequência, comportamento, etc.) filtrados por ano letivo e bimestre, incluindo a posição da turma no ranking."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Desempenho da turma encontrado",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ResponseClassEvaluationsDTO.class))),
-            @ApiResponse(responseCode = "401", description = "Usuário não autenticado"),
-            @ApiResponse(responseCode = "404", description = "Turma não encontrada"),
-            @ApiResponse(responseCode = "500", description = "Erro interno no servidor")
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Desempenho da turma recuperado com sucesso",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseclassificationsClassDTO.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Parâmetros de entrada inválidos (ex: bimestre fora do intervalo 1-4)"),
+            @ApiResponse(responseCode = "401", description = "Usuário não autenticado ou token inválido"),
+            @ApiResponse(responseCode = "404", description = "Turma não encontrada ou sem dados para o período informado"),
+            @ApiResponse(responseCode = "500", description = "Erro interno ao processar as métricas")
     })
-    public ResponseEntity<ResponseclassificationsClassDTO> getClassEvaluationsById(@PathVariable Integer id, @PathVariable Integer year, StepName bimestre);
+    public ResponseEntity<ResponseclassificationsClassDTO> getClassEvaluationsById(
+            @Parameter(description = "ID único da turma (PK)", example = "1")
+            @PathVariable Integer id,
+
+            @Parameter(description = "Ano letivo de referência", example = "2025")
+            @PathVariable Integer year,
+
+            @Parameter(description = "Bimestre da avaliação (1, 2, 3 ou 4)", example = "1")
+            @PathVariable Integer bimestre
+    );
 
     @Operation(
             summary = "Cadastrar desempenho do Aluno",

--- a/src/main/java/br/com/ifrn/AcademicService/dto/StartPeriodDTO.java
+++ b/src/main/java/br/com/ifrn/AcademicService/dto/StartPeriodDTO.java
@@ -3,7 +3,6 @@ package br.com.ifrn.AcademicService.dto;
 import br.com.ifrn.AcademicService.models.enums.StepName;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/br/com/ifrn/AcademicService/models/ClassComments.java
+++ b/src/main/java/br/com/ifrn/AcademicService/models/ClassComments.java
@@ -1,5 +1,6 @@
 package br.com.ifrn.AcademicService.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -39,6 +40,7 @@ public class ClassComments {
     @ManyToOne
     @JoinColumn(name = "class_id", nullable = false)
     @NotAudited
+    @JsonIgnore
     private Classes classe;
 
 

--- a/src/main/java/br/com/ifrn/AcademicService/models/ClassEvaluations.java
+++ b/src/main/java/br/com/ifrn/AcademicService/models/ClassEvaluations.java
@@ -38,7 +38,7 @@ public class ClassEvaluations {
     @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
     private EvaluationPeriod evaluationPeriod;
 
-    public void setEvaluationPeriod(Optional<EvaluationPeriod> activePeriod) {
-
+    public void setEvaluationPeriod(EvaluationPeriod evaluationPeriod) {
+        this.evaluationPeriod = evaluationPeriod;
     }
 }

--- a/src/main/java/br/com/ifrn/AcademicService/models/Classes.java
+++ b/src/main/java/br/com/ifrn/AcademicService/models/Classes.java
@@ -37,13 +37,14 @@ public class Classes {
     @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
     private List<ClassComments> comments;
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @JsonIgnore
     private List<String> userId;
 
     private String classId; //id da turma fornecido na planilha
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
+    @JsonIgnore
     private List<String> professors;
 
 }

--- a/src/main/java/br/com/ifrn/AcademicService/models/enums/StepName.java
+++ b/src/main/java/br/com/ifrn/AcademicService/models/enums/StepName.java
@@ -4,15 +4,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum StepName {
+    PRIMEIRO(1, "1° Bimestre"),
+    SEGUNDO(2, "2° Bimestre"),
+    TERCEIRO(3, "3° Bimestre"),
+    QUARTO(4, "4° Bimestre");
 
-    PRIMEIRO("1° Bimestre"),
-    SEGUNDO("2° Bimestre"),
-    TERCEIRO("3° Bimestre"),
-    QUARTO("4° Bimestre");
-
+    private final int id;
     private final String descricao;
 
-    StepName(String descricao) {
+    StepName(int id, String descricao) {
+        this.id = id;
         this.descricao = descricao;
     }
 
@@ -21,13 +22,22 @@ public enum StepName {
         return descricao;
     }
 
+    // Método para converter o número (1, 2, 3...) em Enum
+    public static StepName fromId(int id) {
+        for (StepName step : values()) {
+            if (step.id == id) return step;
+        }
+        throw new IllegalArgumentException("Bimestre inválido: " + id);
+    }
+
     @JsonCreator
     public static StepName fromValue(String value) {
-        for (StepName status : StepName.values()) {
-            if (status.descricao.equalsIgnoreCase(value)) {
-                return status;
+        for (StepName step : values()) {
+            // Agora ele aceita tanto "1° Bimestre" quanto "PRIMEIRO"
+            if (step.descricao.equalsIgnoreCase(value) || step.name().equalsIgnoreCase(value)) {
+                return step;
             }
         }
-        throw new IllegalArgumentException("Status inválido: " + value);
+        throw new IllegalArgumentException("Valor inválido: " + value);
     }
 }

--- a/src/main/java/br/com/ifrn/AcademicService/repository/ClassEvaluationsRepository.java
+++ b/src/main/java/br/com/ifrn/AcademicService/repository/ClassEvaluationsRepository.java
@@ -1,5 +1,6 @@
 package br.com.ifrn.AcademicService.repository;
 
+import br.com.ifrn.AcademicService.models.enums.StepName;
 import org.springframework.data.jpa.repository.JpaRepository;
 import br.com.ifrn.AcademicService.models.ClassEvaluations;
 import org.springframework.data.jpa.repository.Query;
@@ -29,5 +30,27 @@ public interface ClassEvaluationsRepository extends JpaRepository<ClassEvaluatio
     EvaluationMetricsProjection findRawMetricsByClassIdAndYear(
             @Param("classId") String classId,
             @Param("year") Integer year
+    );
+
+    @Query("""
+SELECT 
+    AVG(c.frequencyScore) as avgFrequency, 
+    AVG(c.unifirmScore) as avgUniform, 
+    AVG(c.behaviorScore) as avgBehavior, 
+    AVG(c.participationScore) as avgParticipation, 
+    AVG(c.performanceScore) as avgPerformance, 
+    AVG(c.cellPhoneUseScore) as avgCellPhone, 
+    AVG(c.averageScore) as avgTotal 
+FROM ClassEvaluations e 
+JOIN e.criteria c 
+JOIN e.evaluationPeriod p 
+WHERE e.classId = :classId 
+  AND p.referenceYear = :year 
+  AND p.stepName = :step
+""")
+    EvaluationMetricsProjection findMetricsByClassAndYearAndStep(
+            @Param("classId") String classId,
+            @Param("year") Integer year,
+            @Param("step") StepName step
     );
 }

--- a/src/main/java/br/com/ifrn/AcademicService/repository/EvaluationPeriodRepository.java
+++ b/src/main/java/br/com/ifrn/AcademicService/repository/EvaluationPeriodRepository.java
@@ -1,6 +1,7 @@
 package br.com.ifrn.AcademicService.repository;
 
 import br.com.ifrn.AcademicService.models.EvaluationPeriod;
+import br.com.ifrn.AcademicService.models.enums.StepName;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,5 @@ public interface EvaluationPeriodRepository extends JpaRepository<EvaluationPeri
     @Modifying
     @Query("UPDATE EvaluationPeriod e SET e.active = false WHERE e.active = true")
     void deactivateAllActivePeriods();
+    boolean existsByStepNameAndReferenceYear(StepName stepName, Integer referenceYear);
 }

--- a/src/main/java/br/com/ifrn/AcademicService/services/ClassEvaluationsService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/ClassEvaluationsService.java
@@ -75,14 +75,16 @@ public class ClassEvaluationsService {
     public ResponseClassEvaluationsDTO createEvaluation(RequestClassEvaluationsDTO dto, Integer id, String professorId) {
         painelControleService.verifyActivePeriod();
         Classes classes = classesRepository.findById(id).orElseThrow(() -> new NoSuchElementException("Class not found"));
-
+        EvaluationPeriod activePeriod = painelControleService.getActivePeriod()
+                .orElseThrow(() -> new IllegalStateException("Nenhum período de avaliação ativo encontrado"));
         EvaluationsCriteria evaluations = evaluationsMapper.toEvaluationsCriteria(dto);
+        evaluations.setAverageScore(calcAverageScore(dto));
         ClassEvaluations classEvaluations = new  ClassEvaluations();
         classEvaluations.setClassId(classes.getClassId());
         classEvaluations.setProfessorId(professorId);
         classEvaluations.setCriteria(evaluations);
         classEvaluations.setDate(LocalDate.now());
-        classEvaluations.setEvaluationPeriod(painelControleService.getActivePeriod());
+        classEvaluations.setEvaluationPeriod(activePeriod);
         classEvaluations = classEvaluationsRepository.save(classEvaluations);
         return evaluationsMapper.toResponseClassEvaluationsDTO(classEvaluations);
     }

--- a/src/main/java/br/com/ifrn/AcademicService/services/PainelControleService.java
+++ b/src/main/java/br/com/ifrn/AcademicService/services/PainelControleService.java
@@ -76,6 +76,15 @@ public class PainelControleService {
 
     @Transactional
     public void startNewPeriod(StartPeriodDTO data) {
+        boolean alreadyExists = repository.existsByStepNameAndReferenceYear(
+                data.getStepName(),
+                data.getYear()
+        );
+
+        if (alreadyExists) {
+            throw new BusinessRuleException("O ciclo " + data.getStepName().getDescricao() +
+                    " para o ano " + data.getYear() + " já foi criado anteriormente.");
+        }
         repository.deactivateAllActivePeriods();
         LocalDateTime start = LocalDateTime.now();
         LocalDateTime deadline = start.plusWeeks(1);


### PR DESCRIPTION
- Implementa filtragem de métricas por bimestre (StepName) via JPQL.
- Adiciona validação de regra de negócio para impedir duplicidade de ciclos de avaliação.
- Corrige bug de persistência onde o 'evaluation_period_id' era salvo como nulo.
- Remove blocos try-catch genéricos nos controllers em favor do Global Exception Handler.
- Atualiza documentação Swagger/OpenAPI com exemplos e descrições detalhadas.
- Padroniza o enum StepName com identificadores numéricos e métodos utilitários.